### PR TITLE
First, rough implementation of openPMD support for VisualPIC

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -72,3 +72,4 @@ Temporary Items
 /VisualPIC/__main__.spec
 /Compile/Windows/dist
 /Logo/logo_horizontal_transp.xcf
+/UpgradeLog.htm

--- a/README.md
+++ b/README.md
@@ -20,8 +20,6 @@ The main principles under which this application was developed are:
 
 The main capabilities of the program include 2D and 3D visualization of fields and particle data, particle tracking through the simulation, the creation of snapshots and animations, as well as a dedicated visualizer for making eye-catching 3D renders of the simulation.
 
-The code is currently still in its early stages and it only supports OSIRIS data, but it's being actively developed and collaborators are always welcome to join!
-
 ![VisualPIC Screnshot](Logo/VisualPIC.PNG)
 
 ## Installation
@@ -77,4 +75,3 @@ For more details about this and on how to add compatibility for more simulation 
 If you use VisualPIC to produce plots or figures for any scientific work, please provide a reference to the following publication:
 
 A. Ferran Pousa et al., “VisualPIC: A New Data Visualizer and Post-Processor for Particle-in-Cell Codes”, presented at IPAC’17, Copenhagen, Denmark, May 2017, paper TUPIK007.
-

--- a/VisualPIC/DataHandling/customDataElements.py
+++ b/VisualPIC/DataHandling/customDataElements.py
@@ -237,12 +237,17 @@ class LaserIntensityField(CustomField):
     def CalculateField(self, timeStep):
         Ey = self.data["Ey"].GetAllFieldDataISUnits(timeStep)
         Ez = self.data["Ez"].GetAllFieldDataISUnits(timeStep)
+        if self.GetFieldDimension() == '3D':
+            Ex = self.data["Ex"].GetAllFieldDataISUnits(timeStep)
         n_p = self.dataContainer.GetSimulationParameter("n_p") * 1e24
         w_p = math.sqrt(n_p * (self.e)**2 / (self.m_e * self.eps_0)) #plasma freq (1/s)
         lambda_l = self.dataContainer.GetSimulationParameter("lambda_l") * 1e-9 # laser wavelength (m)
         w_l = 2 * math.pi * self.c / lambda_l # laser angular frequency (rad/sec)
         n = math.sqrt(1-(w_p/w_l)**2) # index of refraction
-        E2 = np.square(Ez) + np.square(Ey) # square of electric field modulus
+        if self.GetFieldDimension() == '2D':
+            E2 = np.square(Ez) + np.square(Ey) # square of electric field modulus
+        elif self.GetFieldDimension() == '3D':
+            E2 = np.square(Ez) + np.square(Ey) + np.square(Ex) # square of electric field modulus
         Intensity = self.c*self.eps_0*n/2*E2
         return Intensity
 
@@ -259,12 +264,17 @@ class NormalizedVectorPotential(CustomField):
     def CalculateField(self, timeStep):
         Ey = self.data["Ey"].GetAllFieldDataISUnits(timeStep)
         Ez = self.data["Ez"].GetAllFieldDataISUnits(timeStep)
+        if self.GetFieldDimension() == '3D':
+            Ex = self.data["Ex"].GetAllFieldDataISUnits(timeStep)
         n_p = self.dataContainer.GetSimulationParameter("n_p") * 1e24
         w_p = math.sqrt(n_p * (self.e)**2 / (self.m_e * self.eps_0)) #plasma freq (1/s)
         lambda_l = self.dataContainer.GetSimulationParameter("lambda_l") * 1e-9 # laser wavelength (m)
         w_l = 2 * math.pi * self.c / lambda_l # laser angular frequency (rad/sec)
         n = math.sqrt(1-(w_p/w_l)**2) # index of refraction
-        E2 = np.square(Ez) + np.square(Ey) # square of electric field modulus
+        if self.GetFieldDimension() == '2D':
+            E2 = np.square(Ez) + np.square(Ey) # square of electric field modulus
+        elif self.GetFieldDimension() == '3D':
+            E2 = np.square(Ez) + np.square(Ey) + np.square(Ex) # square of electric field modulus
         Intensity = self.c*self.eps_0*n/2*E2
         a = np.sqrt(7.3e-11 * lambda_l**2 * Intensity) # normalized vector potential
         return a

--- a/VisualPIC/DataHandling/unitConverters.py
+++ b/VisualPIC/DataHandling/unitConverters.py
@@ -20,7 +20,6 @@
 
 import math
 import numpy as np
-import scipy.constants as ct
 
 
 class GeneralUnitConverter(object):
@@ -319,13 +318,7 @@ class OpenPMDUnitConverter(GeneralUnitConverter):
         self._SetNormalizationFactor(None)
 
     def ConvertToISUnits(self, dataElement, data):
-        dataElementName = dataElement.GetName()
-        if dataElementName == "x" or dataElementName == "y" or dataElementName == "z":
-            return data*1e-6 # m
-        elif dataElementName == "Px" or dataElementName == "Py" or dataElementName == "Pz":
-            return data*ct.m_e*ct.c # kg*m/s
-        else:
-            return data
+        return data
 
     def GetTimeInISUnits(self, dataElement, timeStep):
         time = dataElement.GetTimeInOriginalUnits(timeStep)

--- a/VisualPIC/DataHandling/unitConverters.py
+++ b/VisualPIC/DataHandling/unitConverters.py
@@ -20,6 +20,7 @@
 
 import math
 import numpy as np
+import scipy.constants as ct
 
 
 class GeneralUnitConverter(object):
@@ -317,8 +318,14 @@ class OpenPMDUnitConverter(GeneralUnitConverter):
         super().SetSimulationParameters(params)
         self._SetNormalizationFactor(None)
 
-    def ConvertToISUnits(self, dataElementName, data):
-        return data
+    def ConvertToISUnits(self, dataElement, data):
+        dataElementName = dataElement.GetName()
+        if dataElementName == "x" or dataElementName == "y" or dataElementName == "z":
+            return data*1e-6 # m
+        elif dataElementName == "Px" or dataElementName == "Py" or dataElementName == "Pz":
+            return data*ct.m_e*ct.c # kg*m/s
+        else:
+            return data
 
     def GetTimeInISUnits(self, dataElement, timeStep):
         time = dataElement.GetTimeInOriginalUnits(timeStep)

--- a/VisualPIC/DataHandling/unitConverters.py
+++ b/VisualPIC/DataHandling/unitConverters.py
@@ -30,7 +30,7 @@ class GeneralUnitConverter(object):
         self.eps_0 = 8.854187817 * 10**(-12) #As/(Vm)
         self.normalizationFactor = None
         self.SetSimulationParameters(simulationParams)
-    
+
     def SetSimulationParameters(self, params):
         self._simulationParameters = params
 
@@ -145,7 +145,7 @@ class GeneralUnitConverter(object):
         elif dataISUnits == "s":
             if units == "fs":
                 return dataInISUnits * 1e15
-                
+
     def GetTimeInUnits(self, dataElement, units, timeStep):
         if dataElement.hasNonISUnits:
             if units == dataElement.GetTimeOriginalUnits():
@@ -173,7 +173,7 @@ class GeneralUnitConverter(object):
         """ Returns the IS units of the data (only the units, not the data!).
             The purpose of this is to identify"""
         if not dataElement.hasNonISUnits:
-            return dataElement.GetDataOriginalUnits()    
+            return dataElement.GetDataOriginalUnits()
         else:
             dataElementName = dataElement.GetName()
             if dataElementName == "Ex" or dataElementName == "Ey" or dataElementName == "Ez":
@@ -211,7 +211,7 @@ class GeneralUnitConverter(object):
 class OsirisUnitConverter(GeneralUnitConverter):
     def __init__(self, simulationParams):
         super(OsirisUnitConverter, self).__init__(simulationParams)
-        
+
     def _SetNormalizationFactor(self, value):
         """ In OSIRIS the normalization factor is the plasma density and it's given in units of 10^18 cm^-3 """
         self.normalizationFactor = value * 1e24
@@ -247,7 +247,7 @@ class OsirisUnitConverter(GeneralUnitConverter):
     def GetTimeInISUnits(self, dataElement, timeStep):
         time = dataElement.GetTimeInOriginalUnits(timeStep)
         return time / self.w_p
-    
+
     def GetAxisInISUnits(self, axis, dataElement, timeStep):
         axisData = dataElement.GetAxisDataInOriginalUnits(axis, timeStep)
         return axisData* self.c / self.w_p
@@ -304,21 +304,37 @@ class HiPACEUnitConverter(GeneralUnitConverter):
         return original_grid_size * self.c / self.w_p
 
 
-class PIConGPUUnitConverter(GeneralUnitConverter):
+class OpenPMDUnitConverter(GeneralUnitConverter):
     def __init__(self, simulationParams):
-        super(HiPACEUnitConverter, self).__init__(simulationParams)
-        
+        super(OpenPMDUnitConverter, self).__init__(simulationParams)
+
+    def _SetNormalizationFactor(self, value):
+        # This function is kept for compatibility with VisualPIC
+        # but is not needed for openPMD, since the data is returned in SI
+        pass
+
+    def SetSimulationParameters(self, params):
+        super().SetSimulationParameters(params)
+        self._SetNormalizationFactor(None)
+
+    def ConvertToISUnits(self, dataElementName, data):
+        return data
+
+    def GetTimeInISUnits(self, dataElement, timeStep):
+        time = dataElement.GetTimeInOriginalUnits(timeStep)
+        return time
+
+    def GetAxisInISUnits(self, axis, dataElement, timeStep):
+        axisData = dataElement.GetAxisDataInOriginalUnits(axis, timeStep)
+        return axisData
+
 
 class UnitConverterSelector:
     unitConverters = {
         "Osiris": OsirisUnitConverter,
         "HiPACE": HiPACEUnitConverter,
-        "PIConGPU":PIConGPUUnitConverter
+        "openPMD": OpenPMDUnitConverter
         }
     @classmethod
     def GetUnitConverter(cls, simulationParams):
         return cls.unitConverters[simulationParams["SimulationCode"]](simulationParams)
-
-        
-        
-        

--- a/VisualPIC/DataReading/dataReaderSelectors.py
+++ b/VisualPIC/DataReading/dataReaderSelectors.py
@@ -20,11 +20,10 @@
 from VisualPIC.DataReading.rawDataReaders import *
 from VisualPIC.DataReading.fieldReaders import *
 
-
 class RawDataReaderSelector:
     dataReaders = {"Osiris": OsirisRawDataReader,
-                   "HiPACE": HiPACERawDataReader
-                   #"PIConGPU": PIConGPURawDataReader
+                   "HiPACE": HiPACERawDataReader,
+                   "openPMD": OpenPMDRawDataReader
                    }
     @classmethod
     def GetReader(cls, simulationCode, location, speciesName, dataName, internalName, firstTimeStep):
@@ -33,8 +32,8 @@ class RawDataReaderSelector:
 
 class FieldReaderSelector:
     dataReaders = {"Osiris": OsirisFieldReader,
-                   "HiPACE": HiPACEFieldReader
-                   #"PIConGPU": PIConGPUFieldReader
+                   "HiPACE": HiPACEFieldReader,
+                   "openPMD": OpenPMDFieldReader
                    }
     @classmethod
     def GetReader(cls, simulationCode, location, speciesName, dataName, firstTimeStep):

--- a/VisualPIC/DataReading/fieldReaders.py
+++ b/VisualPIC/DataReading/fieldReaders.py
@@ -438,7 +438,7 @@ class OpenPMDFieldReader(FieldReaderBase):
         self.axisUnits["y"] = "m"
         self.axisUnits["z"] = "m"
         self.timeUnits = "t"
-        self.dataUnits = "a.u." # TODO find the exact unit; needs navigation in file
+        self.dataUnits = "arb.u." # TODO find the exact unit; needs navigation in file
         file_content.close()
 
     def _ReadSimulationProperties(self, file_content):

--- a/VisualPIC/DataReading/fieldReaders.py
+++ b/VisualPIC/DataReading/fieldReaders.py
@@ -24,12 +24,17 @@ import numpy as np
 
 from VisualPIC.DataReading.dataReader import DataReader
 
-# TODO: Add try/except statement for opmd_viewer
-from opmd_viewer import OpenPMDTimeSeries
-from opmd_viewer.openpmd_timeseries.data_reader.utilities \
-    import get_shape as openpmd_get_shape
-from opmd_viewer.openpmd_timeseries.data_reader.field_reader \
-    import find_dataset as openpmd_find_dataset
+# Try to import openPMD-viewer (required for openPMD data)
+try:
+    from opmd_viewer import OpenPMDTimeSeries
+    from opmd_viewer.openpmd_timeseries.data_reader.utilities \
+        import get_shape as openpmd_get_shape
+    from opmd_viewer.openpmd_timeseries.data_reader.field_reader \
+        import find_dataset as openpmd_find_dataset
+    openpmd_installed = True
+except ImportError:
+    openpmd_installed = False
+
 
 class FieldReaderBase(DataReader):
     """Parent class for all FieldReaders"""
@@ -331,6 +336,10 @@ class HiPACEFieldReader(FieldReaderBase):
 
 class OpenPMDFieldReader(FieldReaderBase):
     def __init__(self, location, speciesName, dataName, firstTimeStep ):
+        # First check whether openPMD is installed
+        if not openpmd_installed:
+            raise RunTimeError("You need to install openPMD-viewer, e.g. with:\n"
+                "pip install openPMD-viewer")
         # Store an openPMD timeseries object
         # (Its API is used in order to conveniently extract data from the file)
         self.openpmd_ts = OpenPMDTimeSeries( location, check_all_files=False )

--- a/VisualPIC/DataReading/fieldReaders.py
+++ b/VisualPIC/DataReading/fieldReaders.py
@@ -24,6 +24,12 @@ import numpy as np
 
 from VisualPIC.DataReading.dataReader import DataReader
 
+# TODO: Add try/except statement for opmd_viewer
+from opmd_viewer import OpenPMDTimeSeries
+from opmd_viewer.openpmd_timeseries.data_reader.utilities \
+    import get_shape as openpmd_get_shape
+from opmd_viewer.openpmd_timeseries.data_reader.field_reader \
+    import find_dataset as openpmd_find_dataset
 
 class FieldReaderBase(DataReader):
     """Parent class for all FieldReaders"""
@@ -137,7 +143,7 @@ class OsirisFieldReader(FieldReaderBase):
 
     def _GetMatrixShape(self, file_content):
         self.matrixShape = file_content.get(self.internalName).shape
-        
+
     def _ReadInternalName(self, file_content):
         self.internalName = list(file_content.keys())[1]
 
@@ -235,7 +241,7 @@ class HiPACEFieldReader(FieldReaderBase):
 
     def _GetMatrixShape(self, file_content):
         self.matrixShape = file_content.get(self.internalName).shape
-        
+
     def _ReadInternalName(self, file_content):
         self.internalName = list(file_content.keys())[0]
 
@@ -315,9 +321,127 @@ class HiPACEFieldReader(FieldReaderBase):
             fileName = 'density_' + self.speciesName + '_' + self.dataName
         else:
             fileName = 'field_' + self.dataName
-            
+
         fileName += '_' + str(timeStep).zfill(6)
         ending = ".h5"
         file_path = self.location + "/" + fileName + ending
         file_content = H5File(file_path, 'r')
+        return file_content
+
+
+class OpenPMDFieldReader(FieldReaderBase):
+    def __init__(self, location, speciesName, dataName, firstTimeStep ):
+        # Store an openPMD timeseries object
+        # (Its API is used in order to conveniently extract data from the file)
+        self.openpmd_ts = OpenPMDTimeSeries( location, check_all_files=False )
+        self.openpmd_dataName = dataName
+        # Initialize the instance
+        FieldReaderBase.__init__(self, location, speciesName, dataName, firstTimeStep)
+
+    def _ReadBasicData(self):
+        file_content = self._OpenFile(self.firstTimeStep)
+        self._ReadInternalName(file_content)
+        self._DetermineFieldDimension(file_content)
+        self._GetMatrixShape(file_content)
+        self._ReadSimulationProperties(file_content)
+        file_content.close()
+
+    def _GetMatrixShape(self, file_content):
+        _, dataset = openpmd_find_dataset( file_content, self.internalName )
+        self.matrixShape = openpmd_get_shape( dataset )
+
+    def _ReadInternalName(self, file_content):
+        self.internalName = self.openpmd_dataName
+
+    def _DetermineFieldDimension(self, file_content):
+        # Find the name of the field ; vector fields like E are encoded as "E/x"
+        fieldname = self.internalName.split("/")[0]
+        geometry = self.openpmd_ts.fields_metadata[fieldname]['geometry']
+        if geometry == '3dcartesian':
+            self.fieldDimension = "3D"
+        elif geometry == '2dcartesian':
+            self.fieldDimension = "2D"
+        else:
+            raise ValueError("Unsupported geometry: %s" %geometry)
+
+    def _Read1DSlice(self, timeStep, slicePositionX, slicePositionY = None):
+        # Find the name of the field ; vector fields like E are encoded as "E/x"
+        field_and_coord = self.internalName.split("/")
+        if self.fieldDimension == '2D':
+            fieldData, _ = self.openpmd_ts.get_field(
+                                *field_and_coord, iteration=timeStep )
+            elementsX = self.matrixShape[-2]
+            selectedRow = round(elementsX*(float(slicePositionX)/100))
+            sliceData = np.array(fieldData[selectedRow])
+        elif self.fieldDimension == '3D':
+            # Slice first along X
+            fieldData = self._Read2DSlice( None, slicePositionX, timeStep )
+            # Then slice along Y
+            elementsY = self.matrixShape[-2]
+            selectedY = round(elementsY*(float(slicePositionY)/100))
+            sliceData = np.array(fieldData[selectedY])
+        return sliceData
+
+    def _Read2DSlice(self, sliceAxis, slicePosition, timeStep):
+        # Find the name of the field ; vector fields like E are encoded as "E/x"
+        field_and_coord = self.internalName.split("/")
+        # Convert the `slicePosition` from a 0-to-100 number to -1 to 1
+        slicing = -1. + 2*slicePosition/100.
+        # Extract the slice
+        sliceData, _ = self.openpmd_ts.get_field(
+                *field_and_coord, iteration=timeStep,
+                slicing_dir="x", slicing=slicing )
+        return sliceData
+
+    def _ReadAllFieldData(self, timeStep):
+        # Find the name of the field ; vector fields like E are encoded as "E/x"
+        field_and_coord = self.internalName.split("/")
+        fieldData, _ = self.openpmd_ts.get_field(
+                        *field_and_coord, iteration=timeStep, slicing=None )
+        return fieldData
+
+    def _ReadAxisData(self, timeStep):
+        # Find the name of the field ; vector fields like E are encoded as "E/x"
+        field_and_coord = self.internalName.split("/")
+        # Note: the code below has very bad performance because
+        # it automatically reads the field data, just to extract the metadata
+        # TODO: improve in the future
+        _, field_meta_data = self.openpmd_ts.get_field( *field_and_coord,
+                                    iteration=timeStep, slicing=None )
+        # Construct the `axisData` from the object `field_meta_data`
+        axisData = {}
+        axisData["x"] = getattr( field_meta_data, field_meta_data.axes[0] )
+        axisData["y"] = getattr( field_meta_data, field_meta_data.axes[1] )
+        if self.fieldDimension == "3D":
+            axisData["z"] = getattr( field_meta_data, field_meta_data.axes[1] )
+        return axisData
+
+    def _ReadTime(self, timeStep):
+        # The line below sets the attribute `_current_i` of openpmd_ts
+        self.openpmd_ts._find_output( None, timeStep )
+        # This sets the corresponding time
+        self.currentTime = self.openpmd_ts.t[ self.openpmd_ts._current_i ]
+
+    def _ReadUnits(self):
+        file_content = self._OpenFile(self.firstTimeStep)
+        # OpenPMD data always provide conversion to SI units
+        self.axisUnits["x"] = "m"
+        self.axisUnits["y"] = "m"
+        self.axisUnits["z"] = "m"
+        self.timeUnits = "t"
+        self.dataUnits = "a.u." # TODO find the exact unit; needs navigation in file
+        file_content.close()
+
+    def _ReadSimulationProperties(self, file_content):
+        # TODO: add the proper resolution
+        self.grid_resolution = None
+        self.grid_size = None
+        self.grid_units = "m"
+
+    def _OpenFile(self, timeStep):
+        # The line below sets the attribute `_current_i` of openpmd_ts
+        self.openpmd_ts._find_output( None, timeStep )
+        # This finds the full path to the corresponding file
+        fileName = self.openpmd_ts.h5_files[ self.openpmd_ts._current_i ]
+        file_content = H5File(fileName, 'r')
         return file_content

--- a/VisualPIC/DataReading/fieldReaders.py
+++ b/VisualPIC/DataReading/fieldReaders.py
@@ -419,10 +419,10 @@ class OpenPMDFieldReader(FieldReaderBase):
                                     iteration=timeStep, slicing=None )
         # Construct the `axisData` from the object `field_meta_data`
         axisData = {}
-        axisData["x"] = getattr( field_meta_data, field_meta_data.axes[0] )
-        axisData["y"] = getattr( field_meta_data, field_meta_data.axes[1] )
+        axisData["x"] = getattr( field_meta_data, "z" )
+        axisData["y"] = getattr( field_meta_data, "x" )
         if self.fieldDimension == "3D":
-            axisData["z"] = getattr( field_meta_data, field_meta_data.axes[1] )
+            axisData["z"] = getattr( field_meta_data, "y" )
         return axisData
 
     def _ReadTime(self, timeStep):

--- a/VisualPIC/DataReading/folderDataReader.py
+++ b/VisualPIC/DataReading/folderDataReader.py
@@ -297,6 +297,7 @@ class FolderDataReader:
         # Scan the folder using openPMD-viewer
         ts = OpenPMDTimeSeries( self._dataLocation, check_all_files=False )
 
+        # TODO: Change hasNonISUnits to False once unit reading is implemented
         # Register the available fields
         if ts.avail_fields is not None:
             for field in ts.avail_fields:
@@ -309,14 +310,16 @@ class FolderDataReader:
                         standardName = self.GiveStandardNameForOpenPMDQuantity(fieldName)
                         self.AddDomainField(
                             FolderField( "openPMD", fieldName, standardName,
-                                        self._dataLocation, ts.iterations ) )
+                                        self._dataLocation, ts.iterations,
+                                        hasNonISUnits = True ) )
                 # Scalar field
                 if ts.fields_metadata[field]['type'] == 'scalar':
                     fieldName = field
                     standardName = self.GiveStandardNameForOpenPMDQuantity(field)
                     self.AddDomainField(
                         FolderField( "openPMD", fieldName, standardName,
-                                    self._dataLocation, ts.iterations ) )
+                                    self._dataLocation, ts.iterations,
+                                    hasNonISUnits = True ) )
 
         # Register the available species
         if ts.avail_species is not None:
@@ -333,7 +336,7 @@ class FolderDataReader:
                             FolderRawDataSet( "openPMD", species_quantity,
                                 self.GiveStandardNameForOpenPMDQuantity(species_quantity),
                                 self._dataLocation, ts.iterations,
-                                species, species_quantity) )
+                                species, species_quantity, hasNonISUnits = True) )
 
     def GetTimeStepsInOpenPMDLocation(self, location):
         ts = OpenPMDTimeSeries( location, check_all_files=False )

--- a/VisualPIC/DataReading/folderDataReader.py
+++ b/VisualPIC/DataReading/folderDataReader.py
@@ -26,9 +26,12 @@ from VisualPIC.DataHandling.species import Species
 from VisualPIC.DataHandling.folderDataElements import FolderField, FolderRawDataSet
 from VisualPIC.DataHandling.rawDataTags import RawDataTags
 
-# Try to import opmd_viewer, for openPMD files
-# TODO: add try/except statements
-from opmd_viewer import OpenPMDTimeSeries
+# Try to import openPMD-viewer (required for openPMD data)
+try:
+    from opmd_viewer import OpenPMDTimeSeries
+    openpmd_installed = True
+except ImportError:
+    openpmd_installed = False
 
 class FolderDataReader:
     """Scans the simulation folder and creates all the necessary species, fields and rawDataSet objects"""
@@ -287,6 +290,10 @@ class FolderDataReader:
     # openPMD
     def LoadOpenPMDData(self):
         """OpenPMD Loader"""
+        # First check whether openPMD is installed
+        if not openpmd_installed:
+            raise RunTimeError("You need to install openPMD-viewer, e.g. with:\n"
+                "pip install openPMD-viewer")
         # Scan the folder using openPMD-viewer
         ts = OpenPMDTimeSeries( self._dataLocation, check_all_files=False )
 

--- a/VisualPIC/DataReading/folderDataReader.py
+++ b/VisualPIC/DataReading/folderDataReader.py
@@ -341,25 +341,31 @@ class FolderDataReader:
 
     def GiveStandardNameForOpenPMDQuantity(self, openpmdName):
         if "E/z" in openpmdName:
-            return "Ez"
-        elif "E/y" in openpmdName:
             return "Ey"
-        elif "E/x" in openpmdName:
+        elif "E/y" in openpmdName:
             return "Ex"
+        elif "E/x" in openpmdName:
+            return "Ez"
         elif "B/z" in openpmdName:
-            return "Bz"
-        elif "B/y" in openpmdName:
             return "By"
-        elif "B/x" in openpmdName:
+        elif "B/y" in openpmdName:
             return "Bx"
+        elif "B/x" in openpmdName:
+            return "Bz"
         elif "rho" in openpmdName:
             return "Charge density"
+        elif openpmdName == "z":
+            return "y"
+        elif openpmdName == "y":
+            return "x"
+        elif openpmdName == "x":
+            return "z"
         elif openpmdName == "uz":
-            return "Pz"
-        elif openpmdName == "uy":
             return "Py"
-        elif openpmdName == "ux":
+        elif openpmdName == "uy":
             return "Px"
+        elif openpmdName == "ux":
+            return "Pz"
         elif openpmdName == "charge":
             return "Charge"
         else:

--- a/VisualPIC/DataReading/folderDataReader.py
+++ b/VisualPIC/DataReading/folderDataReader.py
@@ -344,31 +344,25 @@ class FolderDataReader:
 
     def GiveStandardNameForOpenPMDQuantity(self, openpmdName):
         if "E/z" in openpmdName:
-            return "Ey"
-        elif "E/y" in openpmdName:
-            return "Ex"
-        elif "E/x" in openpmdName:
             return "Ez"
+        elif "E/y" in openpmdName:
+            return "Ey"
+        elif "E/x" in openpmdName:
+            return "Ex"
         elif "B/z" in openpmdName:
-            return "By"
-        elif "B/y" in openpmdName:
-            return "Bx"
-        elif "B/x" in openpmdName:
             return "Bz"
+        elif "B/y" in openpmdName:
+            return "By"
+        elif "B/x" in openpmdName:
+            return "Bx"
         elif "rho" in openpmdName:
             return "Charge density"
-        elif openpmdName == "z":
-            return "y"
-        elif openpmdName == "y":
-            return "x"
-        elif openpmdName == "x":
-            return "z"
         elif openpmdName == "uz":
-            return "Py"
-        elif openpmdName == "uy":
-            return "Px"
-        elif openpmdName == "ux":
             return "Pz"
+        elif openpmdName == "uy":
+            return "Py"
+        elif openpmdName == "ux":
+            return "Px"
         elif openpmdName == "charge":
             return "Charge"
         else:

--- a/VisualPIC/DataReading/rawDataReaders.py
+++ b/VisualPIC/DataReading/rawDataReaders.py
@@ -24,8 +24,12 @@ import numpy as np
 
 from VisualPIC.DataReading.dataReader import DataReader
 
-# TODO: Add try/except statement for openPMD-viewer
-from opmd_viewer import OpenPMDTimeSeries
+# Try to import openPMD-viewer (required for openPMD data)
+try:
+    from opmd_viewer import OpenPMDTimeSeries
+    openpmd_installed = True
+except ImportError:
+    openpmd_installed = False
 
 
 class RawDataReaderBase(DataReader):
@@ -165,6 +169,10 @@ class HiPACERawDataReader(RawDataReaderBase):
 
 class OpenPMDRawDataReader(RawDataReaderBase):
     def __init__(self, location, speciesName, dataName, internalName, firstTimeStep):
+        # First check whether openPMD is installed
+        if not openpmd_installed:
+            raise RunTimeError("You need to install openPMD-viewer, e.g. with:\n"
+                "pip install openPMD-viewer")
         # Store an openPMD timeseries object
         # (Its API is used in order to conveniently extract data from the file)
         self.openpmd_ts = OpenPMDTimeSeries( location, check_all_files=False )

--- a/VisualPIC/DataReading/rawDataReaders.py
+++ b/VisualPIC/DataReading/rawDataReaders.py
@@ -194,12 +194,7 @@ class OpenPMDRawDataReader(RawDataReaderBase):
     def _ReadUnits(self):
         # OpenPMD data always provide conversion to SI units
         # TODO: Get the units from file
-        if self.internalName == "x" or self.internalName == "y" or self.internalName == "z":
-            self.dataUnits = "μm"
-        elif self.internalName == "ux" or self.internalName == "uy" or self.internalName == "uz":
-            self.dataUnits = "m_e*c"
-        else:
-            self.dataUnits = "a.u." 
+        self.dataUnits = "a.u." 
         self.timeUnits = "s"
 
     def _OpenFile(self, timeStep):

--- a/VisualPIC/DataReading/rawDataReaders.py
+++ b/VisualPIC/DataReading/rawDataReaders.py
@@ -193,7 +193,13 @@ class OpenPMDRawDataReader(RawDataReaderBase):
 
     def _ReadUnits(self):
         # OpenPMD data always provide conversion to SI units
-        self.dataUnits = "a.u." # TODO: Get the correct unit
+        # TODO: Get the units from file
+        if self.internalName == "x" or self.internalName == "y" or self.internalName == "z":
+            self.dataUnits = "μm"
+        elif self.internalName == "ux" or self.internalName == "uy" or self.internalName == "uz":
+            self.dataUnits = "m_e*c"
+        else:
+            self.dataUnits = "a.u." 
         self.timeUnits = "s"
 
     def _OpenFile(self, timeStep):

--- a/VisualPIC/DataReading/rawDataReaders.py
+++ b/VisualPIC/DataReading/rawDataReaders.py
@@ -194,7 +194,7 @@ class OpenPMDRawDataReader(RawDataReaderBase):
     def _ReadUnits(self):
         # OpenPMD data always provide conversion to SI units
         # TODO: Get the units from file
-        self.dataUnits = "a.u." 
+        self.dataUnits = "arb.u." 
         self.timeUnits = "s"
 
     def _OpenFile(self, timeStep):

--- a/VisualPIC/Tools/visualizer3Dvtk.py
+++ b/VisualPIC/Tools/visualizer3Dvtk.py
@@ -78,10 +78,8 @@ class VolumeVTK():
             #self.SetOpacityValue(i, point[0], point[1])
 
     def SetCMapRangeFromCurrentTimeStep(self, timeStep):
-        fieldData = np.absolute(self.field.GetAllFieldDataInOriginalUnits(timeStep))
-        self.maxRange = np.amax(fieldData)
-        self.minRange = np.amin(fieldData)
-        self.customCMapRange = True
+        fieldData = self.field.GetAllFieldDataInOriginalUnits(timeStep)
+        self.SetCMapRange(np.amin(fieldData), np.amax(fieldData))
 
     def SetCMapRange(self, min, max):
         self.maxRange = max

--- a/VisualPIC/Tools/visualizer3Dvtk.py
+++ b/VisualPIC/Tools/visualizer3Dvtk.py
@@ -99,9 +99,9 @@ class VolumeVTK():
 
     def GetData(self, timeStep, transvEl = None, longEl = None, fraction = 1):
         if self.field.GetFieldDimension() == "3D":
-            fieldData = np.absolute(self.field.GetAllFieldDataInOriginalUnits(timeStep))
+            fieldData = self.field.GetAllFieldDataInOriginalUnits(timeStep)
         if self.field.GetFieldDimension() == "2D":
-            fieldData = np.absolute(self.field.Get3DFieldFrom2DSliceInOriginalUnits(timeStep, transvEl, longEl, fraction))
+            fieldData = self.field.Get3DFieldFrom2DSliceInOriginalUnits(timeStep, transvEl, longEl, fraction)
         if self.customCMapRange:
             maxvalue = self.maxRange
             minvalue = self.minRange

--- a/VisualPIC/Tools/visualizer3Dvtk.py
+++ b/VisualPIC/Tools/visualizer3Dvtk.py
@@ -244,9 +244,10 @@ class Visualizer3Dvtk():
         # Normalize spacing. Too small values lead to ghost volumes.
         max_sp = max(axesSpacing["x"], axesSpacing["y"], axesSpacing["z"])
         max_cell_size = 0.1 # too big cells turn opaque, too small become transparent
-        axesSpacing["x"] = axesSpacing["x"]/max_sp*max_cell_size
-        axesSpacing["y"] = axesSpacing["y"]/max_sp*max_cell_size
-        axesSpacing["z"] = axesSpacing["z"]/max_sp*max_cell_size
+        norm_factor = max_cell_size/max_sp
+        axesSpacing["x"] = axesSpacing["x"]*norm_factor
+        axesSpacing["y"] = axesSpacing["y"]*norm_factor
+        axesSpacing["z"] = axesSpacing["z"]*norm_factor
         # Put data in VTK format
         dataImport = vtk.vtkImageImport()
         dataImport.SetImportVoidPointer(npdatamulti)
@@ -255,8 +256,7 @@ class Visualizer3Dvtk():
         dataImport.SetDataExtent(0, npdatamulti.shape[2]-1, 0, npdatamulti.shape[1]-1, 0, npdatamulti.shape[0]-1)
         dataImport.SetWholeExtent(0, npdatamulti.shape[2]-1, 0, npdatamulti.shape[1]-1, 0, npdatamulti.shape[0]-1)
         dataImport.SetDataSpacing(axesSpacing["x"],axesSpacing["y"],axesSpacing["z"])
-        #dataImport.SetDataOrigin(axes["x"][0]/max_sp,axes["y"][0]/max_sp,axes["z"][0]/max_sp) # data origin is changed by the normalization
-        dataImport.SetDataOrigin(axes["x"][0],axes["y"][0],axes["z"][0]) # data origin is changed by the normalization
+        dataImport.SetDataOrigin(axes["x"][0]*norm_factor,axes["y"][0]*norm_factor,axes["z"][0]*norm_factor) # data origin is changed by the normalization
         dataImport.Update()
         # Set the mapper
         if self.volumeMapper == None:

--- a/VisualPIC/Tools/visualizer3Dvtk.py
+++ b/VisualPIC/Tools/visualizer3Dvtk.py
@@ -44,7 +44,7 @@ class VolumeVTK():
         self.opacity.AddPoint(255/10*7, 0.7)
         self.opacity.AddPoint(255/10*8, 0.8)
         self.opacity.AddPoint(255/10*9, 0.9)
-        self.opacity.AddPoint(255, 1)
+        self.opacity.AddPoint(255, 0.999) # an opacity of 1 doesnt look good sometimes
         
         self.color.AddRGBPoint(0.0,0, 0, 1)
         self.color.AddRGBPoint(100, 1.000,0, 0)
@@ -127,19 +127,29 @@ class VolumeVTK():
 
     def GetAxesSpacing(self, timeStep, transvEl = None, longEl = None, fraction = 1):
         spacing = {}
-        axesx = self.field.GetAxisDataInOriginalUnits("x", timeStep)
-        axesy = self.field.GetAxisDataInOriginalUnits("y", timeStep)
+        axes = self.GetAxes(timeStep)
         if self.field.GetFieldDimension() == "3D":
-            axesz = self.field.GetAxisDataInOriginalUnits("z", timeStep)
-            spacing["x"] = np.abs(axesx[1]-axesx[0])
-            spacing["y"] = np.abs(axesy[1]-axesy[0])
-            spacing["z"] = np.abs(axesz[1]-axesz[0])
+            spacing["x"] = np.abs(axes["x"][1]-axes["x"][0])
+            spacing["y"] = np.abs(axes["y"][1]-axes["y"][0])
+            spacing["z"] = np.abs(axes["z"][1]-axes["z"][0])
         if self.field.GetFieldDimension() == "2D":
-            axesz = self.field.GetAxisDataInOriginalUnits("y", timeStep)
-            spacing["x"] = np.abs(axesx[-1]-axesx[0])/longEl
-            spacing["y"] = np.abs(axesy[-1]-axesy[0])/transvEl*fraction
-            spacing["z"] = np.abs(axesz[-1]-axesz[0])/transvEl*fraction
+            spacing["x"] = np.abs(axes["x"][-1]-axes["x"][0])/longEl
+            spacing["y"] = np.abs(axes["y"][-1]-axes["y"][0])/transvEl*fraction
+            spacing["z"] = np.abs(axes["y"][-1]-axes["y"][0])/transvEl*fraction
         return spacing
+        #axesx = self.field.GetAxisDataInOriginalUnits("x", timeStep)
+        #axesy = self.field.GetAxisDataInOriginalUnits("y", timeStep)
+        #if self.field.GetFieldDimension() == "3D":
+        #    axesz = self.field.GetAxisDataInOriginalUnits("z", timeStep)
+        #    spacing["x"] = np.abs(axesx[1]-axesx[0])
+        #    spacing["y"] = np.abs(axesy[1]-axesy[0])
+        #    spacing["z"] = np.abs(axesz[1]-axesz[0])
+        #if self.field.GetFieldDimension() == "2D":
+        #    axesz = self.field.GetAxisDataInOriginalUnits("y", timeStep)
+        #    spacing["x"] = np.abs(axesx[-1]-axesx[0])/longEl
+        #    spacing["y"] = np.abs(axesy[-1]-axesy[0])/transvEl*fraction
+        #    spacing["z"] = np.abs(axesz[-1]-axesz[0])/transvEl*fraction
+        #return spacing
 
 class Visualizer3Dvtk():
     def __init__(self, dataContainer):
@@ -231,6 +241,12 @@ class Visualizer3Dvtk():
         npdatamulti = np.concatenate([aux[...,np.newaxis] for aux in npdatauchar], axis=3)
         axes = self.volumeList[0].GetAxes(timeStep)
         axesSpacing = self.volumeList[0].GetAxesSpacing(timeStep, 200, 300, 0.5) # limit on elements only applies for 2d case
+        # Normalize spacing. Too small values lead to ghost volumes.
+        max_sp = max(axesSpacing["x"], axesSpacing["y"], axesSpacing["z"])
+        max_cell_size = 0.1 # too big cells turn opaque, too small become transparent
+        axesSpacing["x"] = axesSpacing["x"]/max_sp*max_cell_size
+        axesSpacing["y"] = axesSpacing["y"]/max_sp*max_cell_size
+        axesSpacing["z"] = axesSpacing["z"]/max_sp*max_cell_size
         # Put data in VTK format
         dataImport = vtk.vtkImageImport()
         dataImport.SetImportVoidPointer(npdatamulti)
@@ -239,7 +255,8 @@ class Visualizer3Dvtk():
         dataImport.SetDataExtent(0, npdatamulti.shape[2]-1, 0, npdatamulti.shape[1]-1, 0, npdatamulti.shape[0]-1)
         dataImport.SetWholeExtent(0, npdatamulti.shape[2]-1, 0, npdatamulti.shape[1]-1, 0, npdatamulti.shape[0]-1)
         dataImport.SetDataSpacing(axesSpacing["x"],axesSpacing["y"],axesSpacing["z"])
-        dataImport.SetDataOrigin(axes["x"][0],axes["y"][0],axes["z"][0])
+        #dataImport.SetDataOrigin(axes["x"][0]/max_sp,axes["y"][0]/max_sp,axes["z"][0]/max_sp) # data origin is changed by the normalization
+        dataImport.SetDataOrigin(axes["x"][0],axes["y"][0],axes["z"][0]) # data origin is changed by the normalization
         dataImport.Update()
         # Set the mapper
         if self.volumeMapper == None:

--- a/VisualPIC/Views/simulationParametersWindow.py
+++ b/VisualPIC/Views/simulationParametersWindow.py
@@ -24,9 +24,9 @@ from PyQt5 import QtCore, QtWidgets
 class SimulationParametersWindow(QtWidgets.QDialog):
     def __init__(self,parent=None):
         super(SimulationParametersWindow, self).__init__(parent)
-        
+
         self.mainWindow = parent
-        self.supportedSimulationCodes = ["Osiris", "HiPACE"]
+        self.supportedSimulationCodes = ["Osiris", "HiPACE", "openPMD"]
         self.verticalLayout = QtWidgets.QVBoxLayout(self)
         self.verticalLayout.setObjectName("verticalLayout")
         self.horizontalLayout = QtWidgets.QHBoxLayout()
@@ -145,7 +145,7 @@ class SimulationParametersWindow(QtWidgets.QDialog):
 
         # Default code options
         self.hiPACEWidget.setVisible(False)
-        
+
     def registerUiEvents(self):
         # General
         self.accept_Button.clicked.connect(self.acceptButton_clicked)
@@ -173,12 +173,11 @@ class SimulationParametersWindow(QtWidgets.QDialog):
         simulationCode = self.simulationCode_comboBox.currentText()
         simParams = dict()
         simParams["SimulationCode"] = simulationCode
-        if simulationCode == "Osiris":
+        if simulationCode == "Osiris" or simulationCode == "openPMD":
             simParams["n_p"] = float(self.osirisPlasmaDensity_lineEdit.text())
             simParams["isLaser"] = self.osirisLaserInSimulation_checkBox.isChecked()
             if simParams["isLaser"]:
                 simParams["lambda_l"] = float(self.osirisLaserWavelength_lineEdit.text())
-        if simulationCode == "HiPACE":
-            simParams["n_p"] = float(self.osirisPlasmaDensity_lineEdit.text())
+
         self.mainWindow.dataContainer.SetSimulationParameters(simParams)
         self.close()

--- a/VisualPIC/Views/simulationParametersWindow.py
+++ b/VisualPIC/Views/simulationParametersWindow.py
@@ -104,6 +104,31 @@ class SimulationParametersWindow(QtWidgets.QDialog):
         self.hiPACEVerticalLayout.addLayout(self.hiPACEHorizontalLayout)
         self.code_layouts.addWidget(self.hiPACEWidget)
 
+        # openPMD layout
+        self.openPMDWidget = QtWidgets.QWidget()
+        self.openPMDVerticalLayout = QtWidgets.QVBoxLayout(self.openPMDWidget)
+        self.openPMDVerticalLayout.setObjectName("openPMDVerticalLayout")
+        self.openPMDHorizontalLayout = QtWidgets.QHBoxLayout()
+        self.openPMDHorizontalLayout.setObjectName("openPMDHorizontalLayout")
+        self.openPMDVerticalLayout.addLayout(self.openPMDHorizontalLayout)
+        self.openPMDHorizontalLayout_4 = QtWidgets.QHBoxLayout()
+        self.openPMDHorizontalLayout_4.setObjectName("openPMDHorizontalLayout_4")
+        self.openPMDLaserInSimulation_checkBox = QtWidgets.QCheckBox(self)
+        self.openPMDLaserInSimulation_checkBox.setObjectName("openPMDLaserInSimulation_checkBox")
+        self.openPMDHorizontalLayout_4.addWidget(self.openPMDLaserInSimulation_checkBox)
+        self.openPMDVerticalLayout.addLayout(self.openPMDHorizontalLayout_4)
+        self.openPMDHorizontalLayout_2 = QtWidgets.QHBoxLayout()
+        self.openPMDHorizontalLayout_2.setObjectName("openPMDHorizontalLayout_2")
+        self.openPMDLabel_2 = QtWidgets.QLabel(self)
+        self.openPMDLabel_2.setObjectName("openPMDLabel_2")
+        self.openPMDHorizontalLayout_2.addWidget(self.openPMDLabel_2)
+        self.openPMDLaserWavelength_lineEdit = QtWidgets.QLineEdit(self)
+        self.openPMDLaserWavelength_lineEdit.setMaximumSize(QtCore.QSize(100, 16777215))
+        self.openPMDLaserWavelength_lineEdit.setObjectName("openPMDLaserWavelength_lineEdit")
+        self.openPMDHorizontalLayout_2.addWidget(self.openPMDLaserWavelength_lineEdit)
+        self.openPMDVerticalLayout.addLayout(self.openPMDHorizontalLayout_2)
+        self.code_layouts.addWidget(self.openPMDWidget)
+
         # General
         self.accept_Button = QtWidgets.QPushButton(self)
         self.accept_Button.setObjectName("accept_Button")
@@ -143,8 +168,19 @@ class SimulationParametersWindow(QtWidgets.QDialog):
         elif simParams["SimulationCode"] == "HiPACE":
             self.hiPACEPlasmaDensity_lineEdit.setText(str(simParams["n_p"]))
 
+        # openPMD
+        self.openPMDLabel_2.setText("Laser wavelength (nm):")
+        self.openPMDLaserInSimulation_checkBox.setText("Laser in simulation.")
+        if (len(simParams) == 0) or (simParams["SimulationCode"] != "openPMD"):
+            self.openPMDLaserWavelength_lineEdit.setText("800")
+            self.openPMDLaserInSimulation_checkBox.setChecked(True)
+        elif simParams["SimulationCode"] == "openPMD":
+            self.openPMDLaserWavelength_lineEdit.setText(str(simParams["lambda_l"]))
+            self.openPMDLaserInSimulation_checkBox.setChecked(simParams["isLaser"])
+
         # Default code options
         self.hiPACEWidget.setVisible(False)
+        self.openPMDWidget.setVisible(False)
 
     def registerUiEvents(self):
         # General
@@ -152,13 +188,21 @@ class SimulationParametersWindow(QtWidgets.QDialog):
         self.simulationCode_comboBox.currentIndexChanged.connect(self.simulationCodeComboBox_IndexChanged)
         # Osiris
         self.osirisLaserInSimulation_checkBox.toggled.connect(self.osirisLaserInSimulationCheckBox_StatusChanged)
+        # openPMD
+        self.openPMDLaserInSimulation_checkBox.toggled.connect(self.openPMDLaserInSimulationCheckBox_StatusChanged)
 
     def simulationCodeComboBox_IndexChanged(self):
         if self.simulationCode_comboBox.currentText() == "Osiris":
+            self.openPMDWidget.setVisible(False)
             self.hiPACEWidget.setVisible(False)
             self.osirisWidget.setVisible(True)
         elif self.simulationCode_comboBox.currentText() == "HiPACE":
+            self.openPMDWidget.setVisible(False)
             self.hiPACEWidget.setVisible(True)
+            self.osirisWidget.setVisible(False)
+        elif self.simulationCode_comboBox.currentText() == "openPMD":
+            self.openPMDWidget.setVisible(True)
+            self.hiPACEWidget.setVisible(False)
             self.osirisWidget.setVisible(False)
 
     def acceptButton_clicked(self):
@@ -169,6 +213,11 @@ class SimulationParametersWindow(QtWidgets.QDialog):
         self.osirisLaserWavelength_lineEdit.setEnabled(status)
         self.osirisLabel_2.setEnabled(status)
 
+    def openPMDLaserInSimulationCheckBox_StatusChanged(self):
+        status = self.openPMDLaserInSimulation_checkBox.isChecked()
+        self.openPMDLaserWavelength_lineEdit.setEnabled(status)
+        self.openPMDLabel_2.setEnabled(status)
+
     def SetSimulationParameters(self):
         simulationCode = self.simulationCode_comboBox.currentText()
         simParams = dict()
@@ -178,6 +227,12 @@ class SimulationParametersWindow(QtWidgets.QDialog):
             simParams["isLaser"] = self.osirisLaserInSimulation_checkBox.isChecked()
             if simParams["isLaser"]:
                 simParams["lambda_l"] = float(self.osirisLaserWavelength_lineEdit.text())
+        elif simulationCode == "HiPACE":
+            simParams["n_p"] = float(self.hiPACEPlasmaDensity_lineEdit.text())
+        elif simulationCode == "openPMD":
+            simParams["isLaser"] = self.openPMDLaserInSimulation_checkBox.isChecked()
+            if simParams["isLaser"]:
+                simParams["lambda_l"] = float(self.openPMDLaserWavelength_lineEdit.text())
 
         self.mainWindow.dataContainer.SetSimulationParameters(simParams)
         self.close()


### PR DESCRIPTION
This is a quick implementation of [openPMD](https://github.com/openPMD) support for VisualPIC.

The general idea is to use the light-weight package [openPMD-viewer](https://github.com/openPMD/openPMD-viewer) to access the data. This is in order to avoid duplicating a lot of code (for reading data, inferring dimension, etc.) which is already present in `openPMD-viewer`. While this drastically reduces the amount of code to be implemented in VisualPIC, it also adds an additional dependency.

The implementation creates multiple instances of `OpenPMDTimeSeries` (e.g. one per `FieldDataReader` and `RawDataReader`) which is not ideal: Each time one of these instance is created, the whole data folder is scanned over again, which can take some time. I used the option `check_all_files=False` which prevents `openPMD-viewer` from doing additional consistency checks between the different files corresponding to different time steps. That way, the folder scan is limited to the minimum (listing the files and getting the corresponding time and timesteps).

This implementation can be tested for instance with files from: https://github.com/openPMD/openPMD-example-datasets

Note that I removed the unimplemented stubs for PIConGPU and replaced them by the equivalent openPMD methods. (since PIConGPU now uses openPMD)

Also, sorry for all the empty white line suppression, which makes this PR slightly more difficult to read ; this is an automatic setting of my text editor that I forgot to turn off.

Here are few things that could be improved, through future pull requests:
- The 3D renderer is not able to properly render openPMD data unless the user explicitly enters the min and max value of the fields.
- Cylindrical geometry (e.g. with azimuthal decomposition) is not yet implemented.
- Some of the functions are not very efficient because they read e.g. the whole mesh, just to extract field metadata. I'll add a method in openPMD-viewer that just extracts the field metadata, without reading the whole mesh.
- The units are currently set to "a.u.". I'll add a method that conveniently extracts the units in `openPMD-viewer`.
