### PR TITLE
Allow new versions of openPMD-viewer, beyond 1.0.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,5 +5,5 @@ pillow
 h5py
 matplotlib
 vtk
-openpmd-viewer==1.0.0
+openpmd-viewer>=1.0.0
 aptools


### PR DESCRIPTION
I noticed that the branch `general_redesign` imposes version `1.0.0` explicitly for `openPMD-viewer`. 
However, as we are going to release new versions of `openPMD-viewer` (e.g. `1.0.1`, for minor bug fixes), it might be good to allow those new versions - as is done in this PR.