### PR TITLE
HiPACE fixes

### DIFF
--- a/visualpic/data_reading/field_readers.py
+++ b/visualpic/data_reading/field_readers.py
@@ -250,9 +250,10 @@ class HiPACEFieldReader(FieldReader):
                             slice_j=0.5, slice_dir_i=None, slice_dir_j=None):
         file = H5F(file_path, 'r')
         fld = file[field_path]
+        fld = np.moveaxis(fld, 0, 2)
         if slice_dir_i is not None:
             fld_shape = fld.shape
-            axis_order = ['z', 'x', 'y']
+            axis_order = ['x', 'y', 'z']
             slice_list = [slice(None)] * fld.ndim
             axis_idx_i = axis_order.index(slice_dir_i)
             axis_elements_i = fld_shape[axis_idx_i]

--- a/visualpic/data_reading/folder_scanners.py
+++ b/visualpic/data_reading/folder_scanners.py
@@ -653,7 +653,8 @@ class HiPACEFolderScanner(FolderScanner):
         A tuple with a an array of file paths and and array of timesteps.
         """
         field_files = [os.path.join(folder_path, file) for file in
-                       files_in_folder if (prefix in file) and (name in file)]
+                       files_in_folder if ((prefix in file) and (name in file)
+                                           and (file.endswith('.h5')))]
         time_steps = np.zeros(len(field_files))
         for i, file in enumerate(field_files):
             time_step = int(file.split('_')[-1].split('.')[0])

--- a/visualpic/data_reading/folder_scanners.py
+++ b/visualpic/data_reading/folder_scanners.py
@@ -469,7 +469,7 @@ class HiPACEFolderScanner(FolderScanner):
         for file in files_in_folder:
             if file.endswith('.h5'):
                 if 'density' in file:
-                    species_name = file.split('_')[1]
+                    species_name = '_'.join(file.split('_')[1:-1])
                     if species_name not in species_names:
                         species_names.append(species_name)
                 elif 'field' in file:

--- a/visualpic/data_reading/folder_scanners.py
+++ b/visualpic/data_reading/folder_scanners.py
@@ -507,7 +507,7 @@ class HiPACEFolderScanner(FolderScanner):
         for file in files_in_folder:
             if file.endswith('.h5'):
                 if 'raw' in file:
-                    species_name = file.split('_')[1]
+                    species_name = '_'.join(file.split('_')[1:-1])
                     if species_name not in species_names:
                         species_names.append(species_name)
         available_species = []

--- a/visualpic/data_reading/particle_readers.py
+++ b/visualpic/data_reading/particle_readers.py
@@ -123,7 +123,11 @@ class HiPACEParticleReader(ParticleReader):
 
     def _read_component_data(self, file_path, species, component):
         with H5F(file_path, 'r') as file_handle:
-            data = file_handle[self.name_relations[component]]
+            if component in self.name_relations:
+                hp_name = self.name_relations[component]
+            else:
+                hp_name = component
+            data = file_handle[hp_name]
             if component == 'tag':
                 # Apply Cantor pairing function
                 print(data)
@@ -141,6 +145,8 @@ class HiPACEParticleReader(ParticleReader):
                 units = 'm_ec'
             elif component == 'q':
                 units = 'qnorm'
+            else:
+                units = ''
             metadata['units'] = units
             metadata['time'] = {}
             metadata['time']['value'] = file_handle.attrs['TIME'][0]

--- a/visualpic/visualization/vtk_visualizer.py
+++ b/visualpic/visualization/vtk_visualizer.py
@@ -1224,11 +1224,11 @@ class VolumetricField():
             max_fld = np.max(fld_data)
             self._original_data_range = [min_fld, max_fld]
             fld_data = self._normalize_field(fld_data)
-            # Making fld_data a new numpy array fixes a crash in
-            # vtk_data_import.SetImportVoidPointer in some cases when trimming
-            # in the y or z planes is applied. It is not clear why this
-            # happens.
-            self._field_data = np.array(fld_data)
+            # Make sure the array is contiguous, otherwise this can lead to 
+            # errors in vtk_data_import.SetImportVoidPointer in some cases when
+            # trimming in the y or z planes is applied, or when the array has
+            # been rearranged in the FieldReader (such as for HiPACE data).
+            self._field_data = np.ascontiguousarray(fld_data)
             self._field_metadata = fld_md
             if not only_metadata:
                 self._loaded_timestep = timestep


### PR DESCRIPTION
This PR includes several bug fixes for HiPACE data. In particular:

* The axis (index) order of the field arrays has been changed to be the same as in the other supported codes.
* Fixed crash when the species name has more than one word.
* Fixed crash when non-hdf5 files with the name of some field or species were present in the data folder.
* Fixed crash when some particle component is not recognized.

In addition, a bug has been fixed in the `VTKVisualizer` when then field data arrays are not contiguous.