### PR TITLE
Upgrade to openPMD-viewer 1.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,8 +15,8 @@ VisualPIC is currently undergoing a major rewrite of its codebase. Certain limit
 This branch contains the latest developments in the new redesign and gives you a preview of what is ahead for `VisualPIC 0.5`. At the time of writing, the main features of the APIs for  data reading and 3D visualization have been implemented. The images below (as well the render on top) showcase some of the possibilities offered by this new version.
 
 <p align="center">
-  <img alt="Sample image" src="images/sample_image_3d_renderer.png" width="350px" />
-  <img alt="Sample image" src="images/sample_image_3d_renderer_6.png" width="350px" />
+  <img alt="Sample image" src="images/sample_image_3d_renderer.png" width="400px" />
+  <img alt="Sample image" src="images/sample_image_3d_renderer_6.png" width="400px" />
 </p>
 
 If you want to test it by yourself, follow the instructions below and check out the provided example [here](https://github.com/AngelFP/VisualPIC/tree/general_redesign/examples/example_1).

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ![Highlight image](images/highlight_image.png)
 
-## Welcome to a redesigned VisualPIC experience
+## v0.5: A redesigned VisualPIC
 
 VisualPIC is currently undergoing a major rewrite of its codebase. Certain limitations in the design of the initial versions led to ever growing issues and unnecessary complexity when expanding its functionality to, for example, handle data with different geometries. To overcome these and other problems, a new completely redesigned version is being developed with a focus on the following key aspects:
 
@@ -15,45 +15,30 @@ VisualPIC is currently undergoing a major rewrite of its codebase. Certain limit
 This branch contains the latest developments in the new redesign and gives you a preview of what is ahead for `VisualPIC 0.5`. At the time of writing, the main features of the APIs for  data reading and 3D visualization have been implemented. The images below (as well the render on top) showcase some of the possibilities offered by this new version.
 
 <p align="center">
-  <img alt="Sample image" src="images/sample_image_3d_renderer.png" width="450px" />
-  <img alt="Sample image" src="images/sample_image_3d_renderer_6.png" width="450px" />
+  <img alt="Sample image" src="images/sample_image_3d_renderer.png" width="350px" />
+  <img alt="Sample image" src="images/sample_image_3d_renderer_6.png" width="350px" />
 </p>
 
 If you want to test it by yourself, follow the instructions below and check out the provided example [here](https://github.com/AngelFP/VisualPIC/tree/general_redesign/examples/example_1).
 
 ## How to install this new version
 
-1) If you don't have Python (version 3.5 or higher) already installed, download the latest version, for example, from [here](https://www.python.org/downloads/release/python-352/). Choose the 64-bit version if possible to avoid memory limitations. It is recommended to create a virtual environment for `VisualPIC` (you can see how [here](https://docs.python.org/3/library/venv.html), for example). Remember to activate the new environment before proceeding with the installation.
+1) For using with openPMD data, the latest `dev` version of [`openPMD-viewer`](https://github.com/openPMD/openPMD-viewer) is required (some needed features are not yet available on the PyPI package):
 
-2) Clone this repository to a directory in your computer using `git`
 ```bash
-git clone https://github.com/AngelFP/VisualPIC.git
-```
-or simply download the code from [here](https://github.com/AngelFP/VisualPIC/archive/general_redesign.zip) and unzip it.
-
-3) If you haven't already, open a terminal in the newly created folder. If you used git to clone the repository, switch to this branch by typing
-```bash
-git checkout general_redesign
+pip install git+https://github.com/openPMD/openPMD-viewer@dev
 ```
 
-4) After this, perform the installation with
+2) Install this branch of VisualPIC:
 ```bash
-python setup.py install
+pip install git+https://github.com/AngelFP/VisualPIC.git@general_redesign
 ```
 
-5) If you want to use the 3D rendering features and GUI, you will also need to install `VTK`, `pyvista` and `PyQt5`:
+3) If you want to use the 3D rendering features and GUI, you will also need to install `VTK`, `pyvista` and `PyQt5`:
 ```bash
 pip install vtk, pyvista, pyqt5
 ```
 
-6) To get access to some of the 3D visualization features, `vtk 8.2` or higher is required. However, the latest version available on `PyPI` is `8.1.2`. To fix this, you can install version `8.2` from the `conda-forge` repository with
-```bash
-conda install -c conda-forge vtk
-```
-
-## Collaborating
-
-This branch is in active development and contributions are more than welcome, particularly for implementing support for new codes and geometries in the data readers. If you are interested in adding any functionality, start by forking this branch and make a PR once your changes are ready to be merged.
 
 
 ## Citing VisualPIC

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,6 @@ numpy
 scipy
 h5py
 matplotlib
-openpmd-viewer>=1.0.0
+openpmd-viewer>=1.1.0
 aptools
 tqdm

--- a/visualpic/data_handling/data_container.py
+++ b/visualpic/data_handling/data_container.py
@@ -22,7 +22,7 @@ class DataContainer():
     """Class containing a providing access to all the simulation data"""
 
     def __init__(self, simulation_code, data_folder_path, plasma_density=None,
-                 laser_wavelength=0.8e-6):
+                 laser_wavelength=0.8e-6, opmd_backend='h5py'):
         """
         Initialize the data container.
 
@@ -45,11 +45,18 @@ class DataContainer():
         laser_wavelength : float
             Wavelength (in metres) of the laser in the simulation. Needed for
             computing the normalized vector potential.
+
+        opmd_backend : str
+            Used only if `simulation_code='openpmd'`. Specifies the backend to
+            be used by the DataReader of the openPMD-viewer. Possible values
+            are 'h5py' or 'openpmd-api'.
+
         """
         self.simulation_code = simulation_code.lower()
         self.data_folder_path = data_folder_path
         self.sim_params = {'n_p': plasma_density,
                            'lambda_0': laser_wavelength}
+        self.opmd_backend = opmd_backend
         self._set_folder_scanner()
         self.folder_fields = []
         self.particle_species = []
@@ -160,7 +167,7 @@ class DataContainer():
         elif sim_code == 'hipace':
             fs = HiPACEFolderScanner(plasma_density=plasma_density)
         elif sim_code == 'openpmd':
-            fs = OpenPMDFolderScanner()
+            fs = OpenPMDFolderScanner(opmd_backend=self.opmd_backend)
         else:
             raise ValueError("Unsupported code '{}'.".format(sim_code) +
                              " Possible values are 'osiris', 'hipace' or " +

--- a/visualpic/data_handling/data_container.py
+++ b/visualpic/data_handling/data_container.py
@@ -12,9 +12,8 @@ from visualpic.data_handling.derived_field_definitions import (
     derived_field_definitions)
 from visualpic.data_handling.fields import DerivedField
 from visualpic.data_handling.particle_species import ParticleSpecies
-from visualpic.data_reading.folder_scanners import (OsirisFolderScanner,
-                                                    OpenPMDFolderScanner,
-                                                    HiPACEFolderScanner)
+from visualpic.data_reading.folder_scanners import (
+    OsirisFolderScanner, OpenPMDFolderScanner, HiPACEFolderScanner)
 
 
 class DataContainer():

--- a/visualpic/data_handling/derived_field_definitions.py
+++ b/visualpic/data_handling/derived_field_definitions.py
@@ -52,7 +52,7 @@ def calculate_field_name(data_list, sim_geometry, sim_params):
         raise NotImplementedError
     elif sim_geometry == '3dcartesian':
         raise NotImplementedError
-    elif sim_geometry == '2dcylindrical':
+    elif sim_geometry == 'cylindrical':
         raise NotImplementedError
     elif sim_geometry == 'thetaMode':
         raise NotImplementedError
@@ -66,7 +66,7 @@ field_name = {'name': 'F',
               'requirements': {'1d': [],
                                '2dcartesian': [],
                                '3dcartesian': [],
-                               '2dcylindrical': [],
+                               'cylindrical': [],
                                'thetaMode': []},
               'recipe': calculate_field_name}
 
@@ -87,7 +87,7 @@ def calculate_intensity(data_list, sim_geometry, sim_params):
     elif sim_geometry == '3dcartesian':
         Ez, Ex, Ey = data_list
         E2 = Ez**2 + Ex**2 + Ey**2
-    elif sim_geometry == '2dcylindrical':
+    elif sim_geometry == 'cylindrical':
         raise NotImplementedError
     elif sim_geometry == 'thetaMode':
         Ez, Er, Et = data_list
@@ -100,7 +100,7 @@ intensity = {'name': 'I',
              'requirements': {'1d': ['Ez'],
                               '2dcartesian': ['Ez', 'Ex'],
                               '3dcartesian': ['Ez', 'Ex', 'Ey'],
-                              '2dcylindrical': [],
+                              'cylindrical': ['Ez', 'Er'],
                               'thetaMode': ['Ez', 'Er', 'Et']},
              'recipe': calculate_intensity}
 
@@ -120,7 +120,7 @@ def calculate_vector_pot(data_list, sim_geometry, sim_params):
     elif sim_geometry == '3dcartesian':
         Ez, Ex, Ey = data_list
         E2 = Ez**2 + Ex**2 + Ey**2
-    elif sim_geometry == '2dcylindrical':
+    elif sim_geometry == 'cylindrical':
         raise NotImplementedError
     elif sim_geometry == 'thetaMode':
         Ez, Er, Et = data_list
@@ -134,7 +134,7 @@ vector_pot = {'name': 'A',
               'requirements': {'1d': ['Ez'],
                                '2dcartesian': ['Ez', 'Ex'],
                                '3dcartesian': ['Ez', 'Ex', 'Ey'],
-                               '2dcylindrical': [],
+                               'cylindrical': ['Ez', 'Er'],
                                'thetaMode': ['Ez', 'Er', 'Et']},
               'recipe': calculate_vector_pot}
 
@@ -153,7 +153,7 @@ norm_vector_pot = {'name': 'a',
                    'requirements': {'1d': ['Ez'],
                                     '2dcartesian': ['Ez', 'Ex'],
                                     '3dcartesian': ['Ez', 'Ex', 'Ey'],
-                                    '2dcylindrical': [],
+                                    'cylindrical': ['Ez', 'Er'],
                                     'thetaMode': ['Ez', 'Er', 'Et']},
                    'recipe': calculate_norm_vector_pot}
 

--- a/visualpic/data_handling/derived_field_definitions.py
+++ b/visualpic/data_handling/derived_field_definitions.py
@@ -18,7 +18,7 @@ derived_field_definitions = []
 '''
 -------------------------------------------------------------------------------
 Template for adding new derived fields. Copy the code below, uncomment and
-substitude 'Field name' and 'field_name' with the appropiate name.
+substitute 'Field name' and 'field_name' with the appropriate name.
 -------------------------------------------------------------------------------
 
 # Field name

--- a/visualpic/data_handling/derived_particle_data_definitions.py
+++ b/visualpic/data_handling/derived_particle_data_definitions.py
@@ -24,7 +24,7 @@ def get_definition(data_name):
 '''
 -------------------------------------------------------------------------------
 Template for adding new derived particle components. Copy the code below,
-and substitude 'Component name' and 'component_name' with the appropiate name.
+and substitute 'Component name' and 'component_name' with the appropriate name.
 -------------------------------------------------------------------------------
 
 # Component name

--- a/visualpic/data_handling/fields.py
+++ b/visualpic/data_handling/fields.py
@@ -8,8 +8,6 @@ License: GNU GPL-3.0.
 """
 
 
-from copy import copy
-
 from visualpic.helper_functions import get_common_timesteps
 
 

--- a/visualpic/data_handling/fields.py
+++ b/visualpic/data_handling/fields.py
@@ -30,18 +30,18 @@ class Field():
     def get_data(self, time_step, field_units=None, axes_units=None,
                  axes_to_convert=None, time_units=None, slice_i=0.5,
                  slice_j=0.5, slice_dir_i=None, slice_dir_j=None, m='all',
-                 theta=0, max_resolution_3d_tm=None, only_metadata=False):
+                 theta=0, max_resolution_3d=None, only_metadata=False):
         raise NotImplementedError
 
     def get_only_metadata(self, time_step, field_units=None, axes_units=None,
                           axes_to_convert=None, time_units=None,
                           slice_dir_i=None, slice_dir_j=None, m='all',
-                          theta=0, max_resolution_3d_tm=None):
+                          theta=0, max_resolution_3d=None):
         fld, fld_md = self.get_data(
             time_step, field_units=field_units, axes_units=axes_units,
             axes_to_convert=axes_to_convert, time_units=time_units,
             slice_dir_i=slice_dir_i, slice_dir_j=slice_dir_j, m=m,
-            theta=theta, max_resolution_3d_tm=max_resolution_3d_tm,
+            theta=theta, max_resolution_3d=max_resolution_3d,
             only_metadata=True)
         return fld_md
 
@@ -67,11 +67,11 @@ class FolderField(Field):
     def get_data(self, time_step, field_units=None, axes_units=None,
                  axes_to_convert=None, time_units=None, slice_i=0.5,
                  slice_j=0.5, slice_dir_i=None, slice_dir_j=None, m='all',
-                 theta=0, max_resolution_3d_tm=None, only_metadata=False):
+                 theta=0, max_resolution_3d=None, only_metadata=False):
         file_path = self._get_file_path(time_step)
         fld, fld_md = self.field_reader.read_field(
             file_path, time_step, self.field_path, slice_i, slice_j,
-            slice_dir_i, slice_dir_j, m, theta, max_resolution_3d_tm,
+            slice_dir_i, slice_dir_j, m, theta, max_resolution_3d,
             only_metadata)
         # perform unit conversion
         unit_list = [field_units, axes_units, time_units]
@@ -100,14 +100,14 @@ class DerivedField(Field):
     def get_data(self, time_step, field_units=None, axes_units=None,
                  axes_to_convert=None, time_units=None, slice_i=0.5,
                  slice_j=0.5, slice_dir_i=None, slice_dir_j=None, m='all',
-                 theta=0, max_resolution_3d_tm=None, only_metadata=False):
+                 theta=0, max_resolution_3d=None, only_metadata=False):
         field_data = []
         for field in self.base_fields:
             fld, fld_md = field.get_data(
                 time_step, field_units='SI',
                 slice_i=slice_i, slice_j=slice_j, slice_dir_i=slice_dir_i,
                 slice_dir_j=slice_dir_j, m=m, theta=theta,
-                max_resolution_3d_tm=max_resolution_3d_tm,
+                max_resolution_3d=max_resolution_3d,
                 only_metadata=only_metadata)
             field_data.append(fld)
         if not only_metadata:

--- a/visualpic/data_handling/particle_species.py
+++ b/visualpic/data_handling/particle_species.py
@@ -17,7 +17,7 @@ class ParticleSpecies():
     """Class providing access to the data of a particle species"""
 
     def __init__(self, species_name, components_in_file, species_timesteps,
-                 species_files, data_reader, unit_converter):
+                 timestep_to_files, data_reader, unit_converter):
         """
         Initialize the particle species.
 
@@ -36,9 +36,10 @@ class ParticleSpecies():
             A sorted numpy array numbering all the timesteps containing data
             of this particle species.
 
-        species_file : list
-            A sorted list of strings (same orders as species_timesteps)
-            containing the path to each data file of this species.
+        timestep_to_files : dict or list
+            A dictionary relating each time step to a data file. Alternatively,
+            a list with the same length and order as species_timesteps
+            containing the path to each data file can also be provided.
 
         data_reader : ParticleReader
             An instance of a ParticleReader of the corresponding simulation
@@ -53,7 +54,11 @@ class ParticleSpecies():
         self.derived_components = self._determine_available_derived_components(
             components_in_file)
         self.timesteps = species_timesteps
-        self.species_files = species_files
+        if type(timestep_to_files) is list:
+            if len(timestep_to_files) == len(species_timesteps):
+                timestep_to_files = dict(
+                    zip(species_timesteps, timestep_to_files))
+        self.timestep_to_files = timestep_to_files
         self.data_reader = data_reader
         self.unit_converter = unit_converter
         self.associated_fields = []
@@ -130,11 +135,11 @@ class ParticleSpecies():
                     "Available components are {}.".format(available_comps))
         # Read data from file
         file_path = self._get_file_path(time_step)
-        folder_data = self._get_file_data(file_path, comp_to_read,
-                                          comp_to_read_units, time_units)
+        folder_data = self._get_file_data(
+            file_path, time_step, comp_to_read, comp_to_read_units, time_units)
         # Compute derived data
         derived_data = self._calculate_derived_data(
-            file_path, derived_components, derived_components_units,
+            file_path, time_step, derived_components, derived_components_units,
             time_units)
         # Join in a single dictionary
         data = {**folder_data, **derived_data}
@@ -199,20 +204,20 @@ class ParticleSpecies():
 
     def _get_file_path(self, time_step):
         """Get the file path corresponding to the specified time step."""
-        ts_i = self.timesteps.tolist().index(time_step)
-        return self.species_files[ts_i]
+        return self.timestep_to_files[time_step]
 
-    def _get_file_data(self, file_path, components_list, data_units,
+    def _get_file_data(self, file_path, iteration, components_list, data_units,
                        time_units):
         """Read the specified components from a data file."""
         data = self.data_reader.read_particle_data(
-            file_path, self.species_name, components_list)
+            file_path, iteration, self.species_name, components_list)
         data = self._convert_data_units(data, components_list, data_units,
                                         time_units)
         return data
 
-    def _calculate_derived_data(self, file_path, data_list, target_data_units,
-                                time_units):
+    def _calculate_derived_data(
+            self, file_path, iteration, data_list, target_data_units,
+            time_units):
         """Calculate the specified derived components."""
         derived_data_dict = {}
         for name in data_list:
@@ -222,7 +227,8 @@ class ParticleSpecies():
             required_data_list = data_def['requirements']
             required_data_units = ['SI'] * len(required_data_list)
             required_data = self._get_file_data(
-                file_path, required_data_list, required_data_units, time_units)
+                file_path, iteration, required_data_list, required_data_units,
+                time_units)
             derived_data = data_def['recipe'](required_data)
             derived_data_md = required_data[required_data_list[0]][1]
             derived_data_md['units'] = data_units

--- a/visualpic/data_handling/particle_species.py
+++ b/visualpic/data_handling/particle_species.py
@@ -198,8 +198,8 @@ class ParticleSpecies():
             data = [data]
         data = set(data)
         comps = self.get_list_of_available_components()
-        flds = self.get_list_of_associated_fields()
-        av_data = set(comps + flds)
+        fields = self.get_list_of_associated_fields()
+        av_data = set(comps + fields)
         return data.issubset(av_data)
 
     def _get_file_path(self, time_step):

--- a/visualpic/data_reading/field_readers.py
+++ b/visualpic/data_reading/field_readers.py
@@ -401,17 +401,15 @@ class OpenPMDFieldReader(FieldReader):
         field, *comp = field_path.split('/')
         if len(comp) > 0:
             comp = comp[0]
+        else:
+            comp = None
         if comp in ['x', 'y']:
-            # fld_r, _ = opmd_fr.read_field_circ(file_path, field + '/r', None,
-            #                                   None, m, theta)
-            # fld_t, _ = opmd_fr.read_field_circ(file_path, field + '/t', None,
-            #                                   None, m, theta)
-            fld_r, info = self.read_field_circ(file_path, iteration, field + '/r', None,
-                                               None, m, theta,
-                                               max_resolution_3d_tm)
-            fld_t, *_ = self.read_field_circ(file_path, iteration, field + '/t', None,
-                                             None, m, theta,
-                                             max_resolution_3d_tm)
+            fld_r, info = self._opmd_reader.read_field_circ(
+                iteration, field, '/r', None, None, m, theta,
+                max_resolution_3d_tm)
+            fld_t, *_ = self._opmd_reader.read_field_circ(
+                iteration, field, '/t', None, None, m, theta,
+                max_resolution_3d_tm)
             if theta is None:
                 # This reconstruction leads to problems on axis
                 nx, ny, nz = len(info.x), len(info.y), len(info.z)
@@ -432,11 +430,9 @@ class OpenPMDFieldReader(FieldReader):
                 # Revert the sign below the axis
                 fld[: int(fld.shape[0] / 2)] *= -1
         else:
-            # fld, _ = opmd_fr.read_field_circ(file_path, field_path, None,
-            #                                 None, m, theta)
-            fld, _ = self.read_field_circ(
-                file_path, iteration, field_path, None, None, m,
-                theta, max_resolution_3d_tm)
+            fld, _ = self._opmd_reader.read_field_circ(
+                iteration, field, comp, None, None, m, theta,
+                max_resolution_3d_tm)
         if slice_dir_i is not None:
             fld_shape = fld.shape
             if theta is None:
@@ -450,138 +446,6 @@ class OpenPMDFieldReader(FieldReader):
             slice_list[axis_idx_i] = slice_idx_i
             fld = fld[tuple(slice_list)]
         return fld
-
-    def read_field_circ(
-            self, filename, iteration, field_path, slice_relative_position,
-            slice_across, m=0, theta=0., max_resolution_3d_tm=None):
-        """
-        Adapted from openpmd_viewer to test reduced resolution in reconstructed
-        3d fields from thetaMode data.
-        """
-        # Open the HDF5 file
-        dfile = opmd_fr.h5py.File(filename, 'r')
-        # Extract the dataset and and corresponding group
-        group, dset = opmd_fr.find_dataset(dfile, iteration, field_path)
-
-        # Extract the metainformation
-        Nm, Nr, Nz = opmd_fr.get_shape(dset)
-        info = opmd_fr.FieldMetaInformation(
-            {0: 'r', 1: 'z'}, (Nr, Nz),
-            group.attrs['gridSpacing'], group.attrs['gridGlobalOffset'],
-            group.attrs['gridUnitSI'], dset.attrs['position'], thetaMode=True)
-
-        # Convert to a 3D Cartesian array if theta is None
-        if theta is None:
-
-            # Get cylindrical info
-            rmax = info.rmax
-            inv_dr = 1./info.dr
-            Fcirc = opmd_fr.get_data(dset)  # (Extracts all modes)
-            nr = Fcirc.shape[1]
-            if m == 'all':
-                modes = [mode for mode in range(0, int(Nm / 2) + 1)]
-            else:
-                modes = [m]
-            modes = np.array(modes, dtype='int')
-            nmodes = len(modes)
-
-            # If necessary, reduce resolution for 3D reconstruction
-            if max_resolution_3d_tm is not None:
-                max_res_lon, max_res_transv = max_resolution_3d_tm
-                nz = Fcirc.shape[2]
-                if nz > max_res_lon:
-                    excess_z = int(np.round(nz/max_res_lon))
-                    Fcirc = Fcirc[:, :, ::excess_z]
-                    info.z = info.z[::excess_z]
-                    info.dz = info.z[1] - info.z[0]
-                if nr > max_res_transv/2:
-                    excess_r = int(np.round(nr/(max_res_transv/2)))
-                    Fcirc = Fcirc[:, ::excess_r, :]
-                    info.r = info.r[::excess_r]
-                    info.dr = info.r[1] - info.r[0]
-                    inv_dr = 1./info.dr
-                    nr = Fcirc.shape[1]
-                #fld_zoom = np.array([1., 1., 1.])
-                # if nr > max_res_transv/2:
-                #    fld_zoom[1] = max_res_transv/nr/2
-                #    info.r = zoom(info.r, fld_zoom[1], order=1)
-                # if nz > max_res_lon:
-                #    fld_zoom[2] = max_res_lon/nz
-                #    info.z = zoom(info.z, fld_zoom[2], order=1)
-                # if any(fld_zoom != 1):
-                #    Fcirc = zoom(Fcirc, fld_zoom, order=0, mode='nearest',
-                #                 prefilter=False)
-
-            # Convert cylindrical data to Cartesian data
-            info._convert_cylindrical_to_3Dcartesian()
-            nx, ny, nz = len(info.x), len(info.y), len(info.z)
-            F_total = np.zeros((nx, ny, nz))
-            opmd_fr.construct_3d_from_circ(
-                F_total, Fcirc, info.x, info.y, modes, nx, ny, nz, nr, nmodes,
-                inv_dr, rmax)
-
-        else:
-
-            # Extract the modes and recombine them properly
-            F_total = np.zeros((2 * Nr, Nz))
-            if m == 'all':
-                # Sum of all the modes
-                # - Prepare the multiplier arrays
-                mult_above_axis = [1]
-                mult_below_axis = [1]
-                for mode in range(1, int(Nm / 2) + 1):
-                    cos = np.cos(mode * theta)
-                    sin = np.sin(mode * theta)
-                    mult_above_axis += [cos, sin]
-                    mult_below_axis += [(-1) ** mode * cos, (-1) ** mode * sin]
-                mult_above_axis = np.array(mult_above_axis)
-                mult_below_axis = np.array(mult_below_axis)
-                # - Sum the modes
-                F = opmd_fr.get_data(dset)  # (Extracts all modes)
-                F_total[Nr:, :] = np.tensordot(mult_above_axis,
-                                               F, axes=(0, 0))[:, :]
-                F_total[:Nr, :] = np.tensordot(mult_below_axis,
-                                               F, axes=(0, 0))[::-1, :]
-            elif m == 0:
-                # Extract mode 0
-                F = opmd_fr.get_data(dset, 0, 0)
-                F_total[Nr:, :] = F[:, :]
-                F_total[:Nr, :] = F[::-1, :]
-            else:
-                # Extract higher mode
-                cos = np.cos(m * theta)
-                sin = np.sin(m * theta)
-                F_cos = opmd_fr.get_data(dset, 2 * m - 1, 0)
-                F_sin = opmd_fr.get_data(dset, 2 * m, 0)
-                F = cos * F_cos + sin * F_sin
-                F_total[Nr:, :] = F[:, :]
-                F_total[:Nr, :] = (-1) ** m * F[::-1, :]
-
-        # Perform slicing if needed
-        if slice_across is not None:
-            # Slice field and clear metadata
-            inverted_axes_dict = {
-                info.axes[key]: key for key in info.axes.keys()}
-            for count, slice_across_item in enumerate(slice_across):
-                slicing_index = inverted_axes_dict[slice_across_item]
-                coord_array = getattr(info, slice_across_item)
-                # Number of cells along the slicing direction
-                n_cells = len(coord_array)
-                # Index of the slice (prevent stepping out of the array)
-                i_cell = int(
-                    0.5 * (slice_relative_position[count] + 1.) * n_cells)
-                i_cell = max(i_cell, 0)
-                i_cell = min(i_cell, n_cells - 1)
-                F_total = np.take(F_total, [i_cell], axis=slicing_index)
-            F_total = np.squeeze(F_total)
-            # Remove the sliced labels from the FieldMetaInformation
-            for slice_across_item in slice_across:
-                info._remove_axis(slice_across_item)
-
-        # Close the file
-        dfile.close()
-
-        return(F_total, info)
 
     def _read_field_metadata(self, file_path, iteration, field_path):
         field, *comp = field_path.split('/')

--- a/visualpic/data_reading/field_readers.py
+++ b/visualpic/data_reading/field_readers.py
@@ -11,10 +11,6 @@ import os
 
 from h5py import File as H5F
 import numpy as np
-from scipy.interpolate import interp2d
-from scipy.ndimage import zoom
-from openpmd_viewer.openpmd_timeseries.data_reader.io_reader import (
-    read_openPMD_params, field_reader as opmd_fr)
 
 
 class FieldReader():

--- a/visualpic/data_reading/field_readers.py
+++ b/visualpic/data_reading/field_readers.py
@@ -217,21 +217,21 @@ class OsirisFieldReader(FieldReader):
             file['/AXIS/AXIS1'].attrs["UNITS"][0])
         axis_data["z"]["array"] = np.linspace(sim_data.attrs['XMIN'][0],
                                               sim_data.attrs['XMAX'][0],
-                                              field_shape[-1]+1)
+                                              field_shape[-1])
         if field_geometry in ["2dcartesian", "3dcartesian"]:
             axis_data['x'] = {}
             axis_data["x"]["units"] = self._numpy_bytes_to_string(
                 file['/AXIS/AXIS2'].attrs["UNITS"][0])
             axis_data["x"]["array"] = np.linspace(sim_data.attrs['XMIN'][1],
                                                   sim_data.attrs['XMAX'][1],
-                                                  field_shape[0]+1)
+                                                  field_shape[0])
         if field_geometry == "3dcartesian":
             axis_data['y'] = {}
             axis_data["y"]["units"] = self._numpy_bytes_to_string(
                 file['/AXIS/AXIS3'].attrs["UNITS"][0])
             axis_data["y"]["array"] = np.linspace(sim_data.attrs['XMIN'][2],
                                                   sim_data.attrs['XMAX'][2],
-                                                  field_shape[1]+1)
+                                                  field_shape[1])
         return axis_data
 
     def _get_time_data(self, file):
@@ -309,17 +309,17 @@ class HiPACEFieldReader(FieldReader):
         axis_data["z"]["units"] = 'c/\\omega_p'
         axis_data["z"]["array"] = np.linspace(file.attrs['XMIN'][0],
                                               file.attrs['XMAX'][0],
-                                              field_shape[0]+1)
+                                              field_shape[0])
         axis_data['x'] = {}
         axis_data["x"]["units"] = 'c/\\omega_p'
         axis_data["x"]["array"] = np.linspace(file.attrs['XMIN'][1],
                                               file.attrs['XMAX'][1],
-                                              field_shape[1]+1)
+                                              field_shape[1])
         axis_data['y'] = {}
         axis_data["y"]["units"] = 'c/\\omega_p'
         axis_data["y"]["array"] = np.linspace(file.attrs['XMIN'][2],
                                               file.attrs['XMAX'][2],
-                                              field_shape[2]+1)
+                                              field_shape[2])
         return axis_data
 
     def _get_time_data(self, file):
@@ -468,10 +468,13 @@ class OpenPMDFieldReader(FieldReader):
             md['axis'][axis]['units'] = 'm'
             ax_min = ax_lims[axis][0]
             ax_max = ax_lims[axis][1]
-            ax_els = ax_el[axis]+1
+            ax_els = ax_el[axis]
             if field_geometry in ['cylindrical', 'thetaMode'] and axis == 'r':
                 ax_min = -ax_max
                 ax_els += ax_el[axis]
+            # FIXME this does not differentiate between
+            # node-centered / cell-centered fields. FieldMetaInformation
+            # does it properly
             md['axis'][axis]['array'] = np.linspace(ax_min, ax_max, ax_els)
         return md
 

--- a/visualpic/data_reading/folder_scanners.py
+++ b/visualpic/data_reading/folder_scanners.py
@@ -12,9 +12,7 @@ import os
 
 import numpy as np
 from h5py import File as H5F
-# from openpmd_viewer.openpmd_timeseries.utilities import list_h5_files
-from openpmd_viewer.openpmd_timeseries.data_reader.h5py_reader import (
-    list_files, read_openPMD_params)
+from openpmd_viewer.openpmd_timeseries.data_reader import DataReader
 
 import visualpic.data_reading.field_readers as fr
 import visualpic.data_reading.particle_readers as pr
@@ -71,8 +69,9 @@ class OpenPMDFolderScanner(FolderScanner):
         Initialize the folder scanner and assign corresponding data readers
         and unit converter.
         """
-        self.field_reader = fr.OpenPMDFieldReader()
-        self.particle_reader = pr.OpenPMDParticleReader()
+        self.opmd_reader = DataReader('h5py')
+        self.field_reader = fr.OpenPMDFieldReader(self.opmd_reader)
+        self.particle_reader = pr.OpenPMDParticleReader(self.opmd_reader)
         self.unit_converter = uc.OpenPMDUnitConverter()
 
     def get_list_of_fields(self, folder_path):
@@ -90,13 +89,13 @@ class OpenPMDFolderScanner(FolderScanner):
         A list of FolderField objects
         """
         field_list = []
-        iterations, iteration_to_file = list_files(folder_path)
+        iterations = self.opmd_reader.list_iterations(folder_path)
 
         # Create dictionary with the necessary data of each field.
         fields = {}
         for it in iterations:
-            file = iteration_to_file[it]
-            t, opmd_params = read_openPMD_params(file, it)
+            file = None  # Not needed for openPMD data.
+            t, opmd_params = self.opmd_reader.read_openPMD_params(it)
             avail_fields = opmd_params['avail_fields']
             if avail_fields is not None:
                 for field in avail_fields:
@@ -175,13 +174,13 @@ class OpenPMDFolderScanner(FolderScanner):
         A list of ParticleSpecies objects
         """
         species_list = []
-        iterations, iteration_to_file = list_files(folder_path)
+        iterations = self.opmd_reader.list_iterations(folder_path)
 
         # Create dictionary with the necessary data of each species.
         found_species = {}
         for it in iterations:
-            file = iteration_to_file[it]
-            t, opmd_params = read_openPMD_params(file, it)
+            file = None  # Not needed for openPMD data.
+            t, opmd_params = self.opmd_reader.read_openPMD_params(it)
             avail_species = opmd_params['avail_species']
             if avail_species is not None:
                 for species in avail_species:

--- a/visualpic/data_reading/folder_scanners.py
+++ b/visualpic/data_reading/folder_scanners.py
@@ -101,9 +101,9 @@ class OpenPMDFolderScanner(FolderScanner):
                 for field in avail_fields:
                     field_metadata = opmd_params['fields_metadata'][field]
                     if field_metadata['type'] == 'vector':
-                        field_comps = field_metadata['axis_labels']
+                        field_comps = field_metadata['avail_components']
                         if field_metadata['geometry'] == 'thetaMode':
-                            field_comps += ['x', 'y', 't']
+                            field_comps += ['x', 'y']
                         for comp in field_comps:
                             field_path = field + '/' + comp
                             field_name = self._get_standard_visualpic_name(

--- a/visualpic/data_reading/folder_scanners.py
+++ b/visualpic/data_reading/folder_scanners.py
@@ -110,7 +110,8 @@ class OpenPMDFolderScanner(FolderScanner):
                     field_metadata = opmd_params['fields_metadata'][field]
                     if field_metadata['type'] == 'vector':
                         field_comps = field_metadata['avail_components']
-                        if field_metadata['geometry'] == 'thetaMode':
+                        if ((field_metadata['geometry'] == 'thetaMode') and
+                            (set(['r', 't']).issubset(field_comps))):
                             field_comps += ['x', 'y']
                         for comp in field_comps:
                             field_path = field + '/' + comp

--- a/visualpic/data_reading/folder_scanners.py
+++ b/visualpic/data_reading/folder_scanners.py
@@ -64,12 +64,20 @@ class OpenPMDFolderScanner(FolderScanner):
 
     "Folder scanner class for openPMD data."
 
-    def __init__(self):
+    def __init__(self, opmd_backend='h5py'):
         """
         Initialize the folder scanner and assign corresponding data readers
         and unit converter.
+
+        Parameters
+        ----------
+
+        opmd_backend : str
+            The backend to be used by the DataReader of the openPMD-viewer.
+            Possible values are 'h5py' or 'openpmd-api'.
+
         """
-        self.opmd_reader = DataReader('h5py')
+        self.opmd_reader = DataReader(opmd_backend)
         self.field_reader = fr.OpenPMDFieldReader(self.opmd_reader)
         self.particle_reader = pr.OpenPMDParticleReader(self.opmd_reader)
         self.unit_converter = uc.OpenPMDUnitConverter()

--- a/visualpic/ui/controls/qt/QVTKRenderWindowInteractor.py
+++ b/visualpic/ui/controls/qt/QVTKRenderWindowInteractor.py
@@ -56,7 +56,6 @@ try:
 except ImportError:
     pass
 
-from vtk.vtkRenderingCore import vtkGenericRenderWindowInteractor, vtkRenderWindow
 
 if PyQtImpl is None:
     # Autodetect the PyQt implementation to use

--- a/visualpic/visualization/vtk_visualizer.py
+++ b/visualpic/visualization/vtk_visualizer.py
@@ -179,9 +179,9 @@ class VTKVisualizer():
 
         max_resolution_3d : list
             Maximum longitudinal and transverse resolution (eg. [1000, 500])
-            that the 3d field generated from thetaMode data should have. This
-            allows for faster reconstruction of the 3d field and less memory
-            usage.
+            that the 3d field generated from thetaMode cylindrical data should
+            have. This allows for faster reconstruction of the 3d field and
+            less memory usage.
 
         """
         if field.get_geometry() in ['cylindrical', 'thetaMode', '3dcartesian']:

--- a/visualpic/visualization/vtk_visualizer.py
+++ b/visualpic/visualization/vtk_visualizer.py
@@ -184,7 +184,7 @@ class VTKVisualizer():
             usage.
 
         """
-        if field.get_geometry() in ['thetaMode', '3dcartesian']:
+        if field.get_geometry() in ['cylindrical', 'thetaMode', '3dcartesian']:
             # check if this field has already been added to a volume
             name_suffix = None
             fld_repeated_idx = 0

--- a/visualpic/visualization/vtk_visualizer.py
+++ b/visualpic/visualization/vtk_visualizer.py
@@ -130,7 +130,7 @@ class VTKVisualizer():
     def add_field(self, field, cmap='viridis', opacity='auto',
                   gradient_opacity='uniform opaque', vmax=None, vmin=None,
                   xtrim=None, ytrim=None, ztrim=None, resolution=None,
-                  max_resolution_3d_tm=[100, 100]):
+                  max_resolution_3d=[100, 100]):
         """
         Add a field to the 3D visualization.
 
@@ -177,7 +177,7 @@ class VTKVisualizer():
             contaning the resolution along z (longitudinal), x and y
             (transverse).
 
-        max_resolution_3d_tm : list
+        max_resolution_3d : list
             Maximum longitudinal and transverse resolution (eg. [1000, 500])
             that the 3d field generated from thetaMode data should have. This
             allows for faster reconstruction of the 3d field and less memory
@@ -195,7 +195,7 @@ class VTKVisualizer():
             # add to volume list
             volume_field = VolumetricField(
                 field, cmap, opacity, gradient_opacity, vmax, vmin, xtrim,
-                ytrim, ztrim, resolution, max_resolution_3d_tm, name_suffix)
+                ytrim, ztrim, resolution, max_resolution_3d, name_suffix)
             self.volume_field_list.append(volume_field)
             self.colorbar_list.append(volume_field.get_colorbar(5))
             self.available_time_steps = self.get_possible_timesteps()
@@ -1022,7 +1022,7 @@ class VolumetricField():
     def __init__(self, field, cmap='viridis', opacity='auto',
                  gradient_opacity='uniform opaque', vmax=None, vmin=None,
                  xtrim=None, ytrim=None, ztrim=None, resolution=None,
-                 max_resolution_3d_tm=None, name_suffix=None):
+                 max_resolution_3d=None, name_suffix=None):
         self.field = field
         self.style_handler = VolumeStyleHandler()
         self.cmap = cmap
@@ -1035,7 +1035,7 @@ class VolumetricField():
         self.ztrim = ztrim
         self.resolution = resolution
         self.name_suffix = name_suffix
-        self.max_resolution_3d_tm = max_resolution_3d_tm
+        self.max_resolution_3d = max_resolution_3d
         self.vtk_opacity = vtk.vtkPiecewiseFunction()
         self.vtk_gradient_opacity = vtk.vtkPiecewiseFunction()
         self.vtk_cmap = vtk.vtkColorTransferFunction()
@@ -1217,7 +1217,7 @@ class VolumetricField():
         if self._loaded_timestep != timestep:
             fld_data, fld_md = self.field.get_data(
                 timestep, theta=None,
-                max_resolution_3d_tm=self.max_resolution_3d_tm)
+                max_resolution_3d=self.max_resolution_3d)
             fld_data = self._trim_field(fld_data)
             fld_data = self._change_resolution(fld_data)
             min_fld = np.min(fld_data)


### PR DESCRIPTION
This PR updates VisualPIC to take advantage of the new features in the latest openPMD-viewer.

## Changes
* Thanks to the new openPMD-api backend, non-HDF5 files are now supported.
* The access to any openPMD data is now handled by the new `DataReader` in openPMD-viewer, which simplifies the implementation in VisualPIC.
* The backend used by the openPMD `DataReader` (either `'h5py'` or `'openpmd-api'`) can be manually specified when creating the `DataContainer`.
* Some custom VisualPIC features have now been directly implemented in openPMD-viewer (https://github.com/openPMD/openPMD-viewer/pull/306, https://github.com/openPMD/openPMD-viewer/pull/307). This greatly simplifies the some parts of the code.
* Added initial support for data in cylindrical geometry.
* Fields in 3D Cartesian geometry are now always returned with [x, y, z] axis order. If the original data has a different order, then the axes are rearranged with `np.moveaxis`.
* `FolderField` and `ParticleSpecies` now have a direct mapping between time steps (iterations) and data files.
* The axes arrays in field metadata used to have one more element than they should. This has now been fixed.
* Other bug fixes.
* Updated README.md with new installation instructions.