### PR TITLE
Deactivate identification of field-related species

### DIFF
--- a/visualpic/data_reading/folder_scanners.py
+++ b/visualpic/data_reading/folder_scanners.py
@@ -130,17 +130,24 @@ class OpenPMDFolderScanner(FolderScanner):
                                 fields[field_name]['iterations'].append(it)
 
                     else:
-                        # This might be specific for FBPIC. Check other codes.
-                        if '_' in field:
-                            name_parts = field.split('_')
-                            field_name = name_parts[0]
-                            if len(name_parts) > 2:
-                                species_name = '_'.join(name_parts[1:])
-                            else:
-                                species_name = name_parts[1]
-                        else:
-                            field_name = field
-                            species_name = None
+                        # The code below tries to identify whether the field is
+                        # associated with a particle species. The
+                        # implementation was only valid for FBPIC and could
+                        # lead to problems in other cases. A better way of
+                        # doing this will be implemented once openPMD 2.0 is
+                        # released, which adds this feature to the standard.
+                        # if '_' in field:
+                        #     name_parts = field.split('_')
+                        #     field_name = name_parts[0]
+                        #     if len(name_parts) > 2:
+                        #         species_name = '_'.join(name_parts[1:])
+                        #     else:
+                        #         species_name = name_parts[1]
+                        # else:
+                        #     field_name = field
+                        #     species_name = None
+                        field_name = field
+                        species_name = None
                         field_name = self._get_standard_visualpic_name(
                             field_name)
                         if field_name not in fields:


### PR DESCRIPTION
This PR deactivates a feature in the openPMD folder scanner which tries to determine whether a field corresponds to a particle species. The implementation was only valid for FBPIC and could lead to problems in other cases where an `'_'` was present in the field name. A better way of identifying whether a field belongs to a species will be implemented once openPMD 2.0 is released,  as this feature will be added to the standard as an optional parameter (see https://github.com/openPMD/openPMD-standard/pull/243, https://github.com/openPMD/openPMD-standard/issues/238).