### PR TITLE
Make sure all axis metadata can be converted

### DIFF
--- a/visualpic/data_handling/unit_converters.py
+++ b/visualpic/data_handling/unit_converters.py
@@ -133,12 +133,13 @@ class UnitConverter():
         if convert_axes:
             for axis, target_units in zip(axes_to_convert, target_axes_units):
                 if target_units != 'SI' and target_units not in self.si_units:
-                    axis_data = field_md['axis'][axis]['array']
-                    axis_units = field_md['axis'][axis]['units']
-                    axis_data = self.convert_data(axis_data, axis_units,
-                                                target_units)
-                    field_md['axis'][axis]['units'] = target_units
-                    field_md['axis'][axis]['array'] = axis_data
+                    axis_md = field_md['axis'][axis]
+                    axis_units = axis_md['units']
+                    for data in ['array', 'spacing', 'min', 'max']:
+                        if data in axis_md:
+                            axis_md[data] = self.convert_data(
+                                axis_md[data], axis_units, target_units)
+                    axis_md['units'] = target_units
 
         # convert time data to desired units
         if convert_time and (target_time_units != 'SI' and

--- a/visualpic/data_handling/unit_converters.py
+++ b/visualpic/data_handling/unit_converters.py
@@ -217,13 +217,14 @@ class UnitConverter():
 
         if convert_axes:
             for axis in axes_to_convert:
-                axis_data = field_md['axis'][axis]['array']
-                axis_units = field_md['axis'][axis]['units']
+                axis_md = field_md['axis'][axis]
+                axis_units = axis_md['units']
                 if axis_units not in self.si_units:
-                    axis_data, axis_units = self.convert_data_to_si(
-                        axis_data, axis_units, field_md)
-                    field_md['axis'][axis]['units'] = axis_units
-                    field_md['axis'][axis]['array'] = axis_data
+                    for data in ['array', 'spacing', 'min', 'max']:
+                        if data in axis_md:
+                            axis_md[data], new_units = self.convert_data_to_si(
+                        axis_md[data], axis_units, field_md)
+                    field_md['axis'][axis]['units'] = new_units
 
         if convert_time:
             time_units = field_md['time']['units']


### PR DESCRIPTION
Some axis metadata attributes such as `spacing`, `max` and `min` where not being converted by the `UnitConverter`. This PR fixes this issue.