### PR TITLE
Add new laser envelope fields

### DIFF
--- a/visualpic/data_reading/folder_scanners.py
+++ b/visualpic/data_reading/folder_scanners.py
@@ -258,6 +258,8 @@ class OpenPMDFolderScanner(FolderScanner):
                           'J/r': 'Jr',
                           'J/t': 'Jt',
                           'rho': 'rho',
+                          'a_mod': 'a_mod',
+                          'a_phase': 'a_phase',
                           'z': 'z',
                           'x': 'x',
                           'y': 'y',


### PR DESCRIPTION
Add the laser envelope fields `a_mod` and `a_phase` (used by Wake-T) to the list of recognized openPMD fields. This prevents a warning from being shown every time data containing these fields is loaded.