### PR TITLE
Make sure qt window does not disappear

### DIFF
--- a/visualpic/visualization/vtk_visualizer.py
+++ b/visualpic/visualization/vtk_visualizer.py
@@ -344,7 +344,7 @@ class VTKVisualizer():
         self.window.SetOffScreenRendering(0)
         if self.vis_config['use_qt']:
             app = QtWidgets.QApplication(sys.argv)
-            BasicRenderWindow(self)
+            self.qt_window = BasicRenderWindow(self)
             app.exec_()
         else:
             self.window.Render()


### PR DESCRIPTION
This PR fixes a bug introduced in #35 where the 3d render window would immediately disappear.