### PR TITLE
Add command-line interface for quick and easy visualization (2D and 3D)

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -50,3 +50,4 @@ test =
 [options.entry_points]
 console_scripts =
     vpic = visualpic.cli.vpic:vpic
+    vpic3d = visualpic.cli.vpic3d:vpic3d

--- a/setup.cfg
+++ b/setup.cfg
@@ -46,3 +46,7 @@ visualpic =
 test =
     pytest
     flake8
+
+[options.entry_points]
+console_scripts =
+    vpic = visualpic.cli.vpic:vpic

--- a/visualpic/__init__.py
+++ b/visualpic/__init__.py
@@ -3,7 +3,7 @@ __version__ = "0.5.0"
 
 # make main classes directly available
 from .data_handling.data_container import DataContainer
-from .visualization.vtk_visualizer import VTKVisualizer
+from .visualization import VTKVisualizer, MplVisualizer
 
 
-__all__ = ['DataContainer', 'VTKVisualizer']
+__all__ = ['DataContainer', 'VTKVisualizer', 'MplVisualizer']

--- a/visualpic/cli/vpic.py
+++ b/visualpic/cli/vpic.py
@@ -6,7 +6,7 @@ import argparse
 from visualpic import DataContainer, MplVisualizer
 
 
-def vpic():    
+def vpic():
     """
     Command-line utility for quick visualization of simulation data using
     the matplotlib backend.
@@ -74,7 +74,7 @@ def parse_arguments(possible_fields, possible_species_components):
     parser = argparse.ArgumentParser(
         description='Visualize a field or particle species'
     )
-    
+
     # Add simulation path as optional positional argument.
     parser.add_argument(
         'path',

--- a/visualpic/cli/vpic.py
+++ b/visualpic/cli/vpic.py
@@ -1,0 +1,108 @@
+""" This module defines the `vpic` command line utility. """
+
+import os
+import argparse
+
+from visualpic import DataContainer, MplVisualizer
+
+
+def vpic():    
+    """
+    Command-line utility for quick visualization of simulation data using
+    the matplotlib backend.
+    """
+    # Define possible fields to plot.
+    possible_fields = [
+        'Ex', 'Ey', 'Ez', 'Er', 'Et', 'Bx', 'By', 'Bz', 'Br', 'Bt',
+        'Jx', 'Jy', 'Jz', 'Jr', 'Jt', 'rho', 'a_mod', 'a_phase']
+
+    # Define possible species components to show.
+    possible_species_components = [
+        'x', 'y', 'z', 'px', 'py', 'pz', 'q']
+
+    # Parse input arguments from the command line.
+    args = parse_arguments(possible_fields, possible_species_components)
+
+    # Get list of fields to show.
+    field_names = []
+    for field in possible_fields:
+        if vars(args)[field]:
+            field_names.append(field)
+
+    # Get list of components to show (currently, only none or 2 ar supported).
+    component_names = []
+    for component in possible_species_components:
+        if vars(args)[component]:
+            component_names.append(component)
+
+    # Get absolute path to simulation folder.
+    abs_path = os.path.abspath(args.path)
+
+    # Load the data.
+    dc = DataContainer(args.code, abs_path)
+    dc.load_data()
+
+    # Get field objects.
+    fields = []
+    for name in field_names:
+        fld = dc.get_field(name)
+        fields.append(fld)
+
+    # Get species object.
+    if len(component_names) > 0:
+        if len(component_names) != 2:
+            raise ValueError('Exactly two species components should be given')
+        if args.species is not None:
+            species_name = args.species
+        else:
+            species_list = dc.get_list_of_species()
+            species_name = species_list[0]
+        species = dc.get_species(species_name)
+
+    # Visualize data
+    vis = MplVisualizer()
+    if len(fields) > 0:
+        vis.field_plot(fields, stacked=False)
+    if len(component_names) > 0:
+        vis.particle_plot(species, x=component_names[0], y=component_names[1])
+    vis.show()
+
+
+def parse_arguments(possible_fields, possible_species_components):
+    """ Parse input arguments for `vpic` """
+    # Initialize parser.
+    parser = argparse.ArgumentParser(
+        description='Visualize a field or particle species'
+    )
+    
+    # Add simulation path as optional positional argument.
+    parser.add_argument(
+        'path',
+        type=str,
+        nargs='?',
+        default='.',
+        help='the path to the data folder'
+    )
+
+    # Add simulation code name as optional argument.
+    parser.add_argument(
+        '-c',
+        '--code',
+        default='openpmd',
+        help='code name for the data format (openpmd, osiris, or hipace)'
+    )
+
+    # Add species name as optional argument.
+    parser.add_argument(
+        '-s',
+        '--species',
+        help='name of the particle species to visualize'
+    )
+
+    # Add possible fields and species components as optional arguments.
+    for field in possible_fields:
+        parser.add_argument('-' + field, action='store_true')
+    for component in possible_species_components:
+        parser.add_argument('-' + component, action='store_true')
+
+    return parser.parse_args()

--- a/visualpic/cli/vpic3d.py
+++ b/visualpic/cli/vpic3d.py
@@ -6,7 +6,7 @@ import argparse
 from visualpic import DataContainer, VTKVisualizer
 
 
-def vpic3d():    
+def vpic3d():
     """
     Command-line utility for quick visualization of simulation data using
     the VTK backend.
@@ -59,7 +59,7 @@ def parse_arguments(possible_fields):
     parser = argparse.ArgumentParser(
         description='Visualize a field or particle species'
     )
-    
+
     # Add simulation path as optional positional argument.
     parser.add_argument(
         'path',

--- a/visualpic/cli/vpic3d.py
+++ b/visualpic/cli/vpic3d.py
@@ -1,0 +1,92 @@
+""" This module defines the `vpic3d` command line utility. """
+
+import os
+import argparse
+
+from visualpic import DataContainer, VTKVisualizer
+
+
+def vpic3d():    
+    """
+    Command-line utility for quick visualization of simulation data using
+    the VTK backend.
+    """
+    # Define possible fields to plot.
+    possible_fields = [
+        'Ex', 'Ey', 'Ez', 'Er', 'Et', 'Bx', 'By', 'Bz', 'Br', 'Bt',
+        'Jx', 'Jy', 'Jz', 'Jr', 'Jt', 'rho', 'a_mod', 'a_phase']
+
+    # Parse input arguments from the command line.
+    args = parse_arguments(possible_fields)
+
+    # Get list of fields to show.
+    field_names = []
+    for field in possible_fields:
+        if vars(args)[field]:
+            field_names.append(field)
+
+    # Get absolute path to simulation folder.
+    abs_path = os.path.abspath(args.path)
+
+    # Load the data.
+    dc = DataContainer(args.code, abs_path)
+    dc.load_data()
+
+    # Get field objects.
+    fields = []
+    for name in field_names:
+        fld = dc.get_field(name)
+        fields.append(fld)
+
+    # Get species object.
+    species_list = []
+    if args.species is not None:
+        for species_name in args.species:
+            species_list.append(dc.get_species(species_name))
+
+    # Visualize data
+    vis = VTKVisualizer()
+    for field in fields:
+        vis.add_field(field)
+    for species in species_list:
+        vis.add_species(species)
+    vis.show()
+
+
+def parse_arguments(possible_fields):
+    """ Parse input arguments for `vpic` """
+    # Initialize parser.
+    parser = argparse.ArgumentParser(
+        description='Visualize a field or particle species'
+    )
+    
+    # Add simulation path as optional positional argument.
+    parser.add_argument(
+        'path',
+        type=str,
+        nargs='?',
+        default='.',
+        help='the path to the data folder'
+    )
+
+    # Add simulation code name as optional argument.
+    parser.add_argument(
+        '-c',
+        '--code',
+        default='openpmd',
+        help='code name for the data format (openpmd, osiris, or hipace)'
+    )
+
+    # Add list of species names as optional argument.
+    parser.add_argument(
+        '-s',
+        '--species',
+        nargs='+',
+        help='list of names of the particle species to visualize'
+    )
+
+    # Add possible fields as optional arguments.
+    for field in possible_fields:
+        parser.add_argument('-' + field, action='store_true')
+
+    return parser.parse_args()

--- a/visualpic/cli/vpic3d.py
+++ b/visualpic/cli/vpic3d.py
@@ -54,7 +54,7 @@ def vpic3d():
 
 
 def parse_arguments(possible_fields):
-    """ Parse input arguments for `vpic` """
+    """ Parse input arguments for `vpic3d` """
     # Initialize parser.
     parser = argparse.ArgumentParser(
         description='Visualize a field or particle species'

--- a/visualpic/visualization/__init__.py
+++ b/visualpic/visualization/__init__.py
@@ -1,0 +1,4 @@
+from .vtk_visualizer import VTKVisualizer
+from .matplotlib import MplVisualizer
+
+__all__ = ['VTKVisualizer', 'MplVisualizer']

--- a/visualpic/visualization/matplotlib/__init__.py
+++ b/visualpic/visualization/matplotlib/__init__.py
@@ -1,0 +1,3 @@
+from .mpl_visualizer import MplVisualizer
+
+__all__ = ['MplVisualizer']


### PR DESCRIPTION
This PR adds a command line interface module to VisualPIC that currently contains two commands for quick and easy visualization of simulation data: `vpic` (for visualization with the matplotlib backend) and `vpic3d` (for 3D visualization with the VTK backend). See examples below.

Usage of `vpic`:
![Animation](https://user-images.githubusercontent.com/20479420/179798786-917c47b9-b852-45f5-a6f7-c25d74693058.gif)

Usage of `vpic3d`:
![Animation2](https://user-images.githubusercontent.com/20479420/179798805-8617513f-b2c7-422f-a166-b1b2e9251c09.gif)

