### PR TITLE
Do not use openpmd viewer `1.4.0`

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -28,7 +28,7 @@ install_requires =
     h5py
     matplotlib
     aptools>=0.1.25
-    openpmd-viewer>=1.2.0
+    openpmd-viewer>=1.2.0, !=1.4.0
     tqdm
 python_requires = >=3.7
 


### PR DESCRIPTION
Avoid this version in the requirements due to a bug in the 3d reconstruction from `thetaMode` data (see https://github.com/openPMD/openPMD-viewer/pull/344).