### PR TITLE
Fix time step bug 2d visualizer

### DIFF
--- a/visualpic/ui/basic_plot_window.py
+++ b/visualpic/ui/basic_plot_window.py
@@ -108,7 +108,7 @@ class BasicPlotWindow(QtWidgets.QMainWindow):
         prev_ts = get_previous_timestep(current_ts, self.available_timesteps)
         if prev_ts != current_ts:
             self.timestep_slider.setValue(prev_ts)
-        self.vp_figure.generate(prev_ts)
+        self.vp_figure.generate(prev_ts, False)
         self.figure_canvas.draw()
         # self.render_timestep(prev_ts)
 
@@ -117,7 +117,7 @@ class BasicPlotWindow(QtWidgets.QMainWindow):
         next_ts = get_next_timestep(current_ts, self.available_timesteps)
         if next_ts != current_ts:
             self.timestep_slider.setValue(next_ts)
-        self.vp_figure.generate(next_ts)
+        self.vp_figure.generate(next_ts, False)
         self.figure_canvas.draw()
         # self.render_timestep(next_ts)
 
@@ -125,7 +125,7 @@ class BasicPlotWindow(QtWidgets.QMainWindow):
         value = self.timestep_slider.value()
         value = get_closest_timestep(value, self.available_timesteps)
         self.timestep_slider.setValue(value)
-        self.vp_figure.generate(value)
+        self.vp_figure.generate(value, False)
         self.figure_canvas.draw()
         # self.render_timestep(value)
 

--- a/visualpic/visualization/matplotlib/mpl_visualizer.py
+++ b/visualpic/visualization/matplotlib/mpl_visualizer.py
@@ -124,17 +124,21 @@ class MplVisualizer():
             q_units=q_units, time_units=time_units, cbar=cbar)
         fig.add_subplot(subplot)
 
-    def show(self, timestep=0):
+    def show(self, timestep=0, ts_is_index=True):
         """Show figure(s).
 
         Parameters
         ----------
         timestep : int, optional
             Time step at which to show the data, by default 0
+        ts_is_index : bool
+            Indicates whether the value provided in 'timestep' is the index of
+            the time step (True) or the numerical value of the time step
+            (False).
         """
         app = QtWidgets.QApplication(sys.argv)
         for figure in self._figure_list:
-            figure.generate(timestep)
+            figure.generate(timestep, ts_is_index)
         self.windows = []
         for figure in self._figure_list:
             self.windows.append(BasicPlotWindow(figure, self))

--- a/visualpic/visualization/matplotlib/plot_containers/figure.py
+++ b/visualpic/visualization/matplotlib/plot_containers/figure.py
@@ -17,14 +17,22 @@ class VPFigure():
 
     def add_subplot(self, subplot):
         self._subplot_list.append(subplot)
+        self.available_time_steps = self.get_available_timesteps()
 
-    def generate(self, timestep):
+    def generate(self, timestep, ts_is_index):
+        if ts_is_index:
+            self._current_timestep = self.available_time_steps[timestep]
+        else:
+            if timestep not in self.available_time_steps:
+                raise ValueError(
+                    'Time step {} is not available.'.format(timestep))
+            self._current_timestep = timestep
         self._mpl_figure.clear()
         gs = self._mpl_figure.add_gridspec(1, len(self._subplot_list))
-        self._current_timestep = timestep
+
         for i, subplot in enumerate(self._subplot_list):
             # ax = self._mpl_figure.add_subplot(gs[i])
-            subplot.plot(timestep, gs[i], self._mpl_figure)
+            subplot.plot(self._current_timestep, gs[i], self._mpl_figure)
         # self._mpl_figure.tight_layout()
 
     def get_available_timesteps(self):


### PR DESCRIPTION
Fixes a crash in the 2d visualizer when the simulation output iterations are not labeled from 0 to n in steps of 1. 