### PR TITLE
Fix crash when `vtk` is not installed

### DIFF
--- a/visualpic/visualization/vtk_visualizer.py
+++ b/visualpic/visualization/vtk_visualizer.py
@@ -34,7 +34,7 @@ except:
 from visualpic.helper_functions import get_common_timesteps
 from visualpic.visualization.volume_appearance import (VolumeStyleHandler,
                                                        Colormap, Opacity)
-if qt_installed:
+if qt_installed and vtk_installed:
     from visualpic.ui.basic_render_window import BasicRenderWindow
 
 


### PR DESCRIPTION
Fixed problem where importing `visualpic` would crash if `pyqt5` but no `vtk` were installed.