### PR TITLE
Pip: Use as a Module

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,14 +23,14 @@ If you want to test it by yourself, follow the instructions below and check out 
 
 ## How to install
 
-1) Install this branch of VisualPIC:
+1) Install the development branch of VisualPIC:
 ```bash
-pip install git+https://github.com/AngelFP/VisualPIC.git@dev
+python3 -m pip install git+https://github.com/AngelFP/VisualPIC.git@dev
 ```
 
 2) If you want to use the 3D rendering features and GUI, you will also need to install `VTK`, `pyvista` and `PyQt5`:
 ```bash
-pip install vtk pyvista pyqt5
+python3 -m pip install vtk pyvista pyqt5
 ```
 
 

--- a/visualpic/visualization/matplotlib/mpl_visualizer.py
+++ b/visualpic/visualization/matplotlib/mpl_visualizer.py
@@ -145,7 +145,7 @@ class MplVisualizer():
         if not qt_installed:
             raise ModuleNotFoundError(
                 "Cannot show visualizer because PyQt5 is not installed. "
-                "Please install by running `pip install pyqt5`.")
+                "Please install by running `python3 -m pip install pyqt5`.")
         # Show window.
         app = QtWidgets.QApplication(sys.argv)
         for figure in self._figure_list:

--- a/visualpic/visualization/vtk_visualizer.py
+++ b/visualpic/visualization/vtk_visualizer.py
@@ -1005,13 +1005,14 @@ class VTKVisualizer():
             dep_str = ', '.join(missing_dependencies)
             raise ImportError(
                 "Missing required dependencies: {}.".format(dep_str) +
-                "Install by running 'pip install {}'.".format(dep_str))
+                "Install by running " +
+                "'python3 -m pip install {}'.".format(dep_str))
 
     def _check_qt(self, use_qt):
         if use_qt and not qt_installed:
             warnings.warn(
                 "Qt is not installed. Default VTK windows will be used. "
-                "Install by running 'pip install pyqt5'.")
+                "Install by running 'python3 -m pip install pyqt5'.")
             use_qt = False
         return use_qt
 


### PR DESCRIPTION
Update Install lines to refer to `pip` as a module of the current python interpreter.

This is the "modern"/recommended way to use pip, avoiding mismatches with environments, etc.
https://packaging.python.org/en/latest/tutorials/installing-packages/#ensure-you-can-run-pip-from-the-command-line