### PR TITLE
openPMD-api: Default openPMD Backend

### DIFF
--- a/visualpic/data_handling/data_container.py
+++ b/visualpic/data_handling/data_container.py
@@ -21,7 +21,7 @@ class DataContainer():
     """Class containing a providing access to all the simulation data"""
 
     def __init__(self, simulation_code, data_folder_path, plasma_density=None,
-                 laser_wavelength=0.8e-6, opmd_backend='h5py'):
+                 laser_wavelength=0.8e-6, opmd_backend='openpmd-api'):
         """
         Initialize the data container.
 

--- a/visualpic/data_reading/folder_scanners.py
+++ b/visualpic/data_reading/folder_scanners.py
@@ -65,7 +65,7 @@ class OpenPMDFolderScanner(FolderScanner):
 
     "Folder scanner class for openPMD data."
 
-    def __init__(self, opmd_backend='h5py'):
+    def __init__(self, opmd_backend='openpmd-api'):
         """
         Initialize the folder scanner and assign corresponding data readers
         and unit converter.

--- a/visualpic/data_reading/openpmd_data_reader.py
+++ b/visualpic/data_reading/openpmd_data_reader.py
@@ -94,7 +94,7 @@ class OpenPMDDataReader(DataReader):
                     self.series, iteration, field, comp)
             elif geometry in ["1dcartesian", "2dcartesian", "3dcartesian"]:
                 return read_cartesian_field_metadata_io(
-                    self.series, iteration, field, comp)
+                    self.series, iteration, field, comp, axis_labels)
 
 
 def read_cartesian_field_metadata_h5py(filename, iteration, field_name,


### PR DESCRIPTION
We changed the default backend in openPMD-viewer to be openPMD-api by now, keeping h5py only as a backup/fallback. This moves the same change here.

Fix `read_cartesian_field_metadata_io` call: Add missing argument for `axis_labels`.