### PR TITLE
Replace `python3` with `python` and fix error message

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,12 +25,12 @@ If you want to test it by yourself, follow the instructions below and check out 
 
 1) Install the development branch of VisualPIC:
 ```bash
-python3 -m pip install git+https://github.com/AngelFP/VisualPIC.git@dev
+python -m pip install git+https://github.com/AngelFP/VisualPIC.git@dev
 ```
 
 2) If you want to use the 3D rendering features and GUI, you will also need to install `VTK`, `pyvista` and `PyQt5`:
 ```bash
-python3 -m pip install vtk pyvista pyqt5
+python -m pip install vtk pyvista pyqt5
 ```
 
 

--- a/visualpic/visualization/matplotlib/mpl_visualizer.py
+++ b/visualpic/visualization/matplotlib/mpl_visualizer.py
@@ -145,7 +145,7 @@ class MplVisualizer():
         if not qt_installed:
             raise ModuleNotFoundError(
                 "Cannot show visualizer because PyQt5 is not installed. "
-                "Please install by running `python3 -m pip install pyqt5`.")
+                "Please install by running `python -m pip install pyqt5`.")
         # Show window.
         app = QtWidgets.QApplication(sys.argv)
         for figure in self._figure_list:

--- a/visualpic/visualization/vtk_visualizer.py
+++ b/visualpic/visualization/vtk_visualizer.py
@@ -1002,17 +1002,17 @@ class VTKVisualizer():
         if not pyvista_installed:
             missing_dependencies.append('pyvista')
         if len(missing_dependencies) > 0:
-            dep_str = ', '.join(missing_dependencies)
+            dep_str = ' '.join(missing_dependencies)
             raise ImportError(
                 "Missing required dependencies: {}.".format(dep_str) +
                 "Install by running " +
-                "'python3 -m pip install {}'.".format(dep_str))
+                "'python -m pip install {}'.".format(dep_str))
 
     def _check_qt(self, use_qt):
         if use_qt and not qt_installed:
             warnings.warn(
                 "Qt is not installed. Default VTK windows will be used. "
-                "Install by running 'python3 -m pip install pyqt5'.")
+                "Install by running 'python -m pip install pyqt5'.")
             use_qt = False
         return use_qt
 


### PR DESCRIPTION
References to the `python3` command have been changed `python`, as the former is not available on Windows. It also fixes a mistake in an error message about missing dependencies, where a comma was used to separate the dependencies to install with `pip`.