### PR TITLE
Fix bug with VTK

### DIFF
--- a/visualpic/visualization/vtk_visualizer.py
+++ b/visualpic/visualization/vtk_visualizer.py
@@ -753,7 +753,7 @@ class VTKVisualizer():
         # only a single volume. The fix replaces the 'vtkMultiVolume' for a
         # 'vtkVolume' and then calls '_load_data_into_single_volume'.
         if len(self.volume_field_list) == 1:
-            if not isinstance(self.vtk_volume, vtk.vtkVolume):
+            if isinstance(self.vtk_volume, vtk.vtkMultiVolume):
                 self.renderer.RemoveVolume(self.vtk_volume)
                 self.vtk_volume = vtk.vtkVolume()
                 self.renderer.AddVolume(self.vtk_volume)


### PR DESCRIPTION
It seems that in newer VTK versions `isinstance(self.vtk_volume, vtk.vtkVolume)` is `True` when `self.vtk_volume` is a `vtk.vtkMultiVolume`. This was leading to a false positive in an `if` condition.