### PR TITLE
setuptools: license_files

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,3 @@
 [build-system]
-requires = ["setuptools", "wheel"]
+requires = ["setuptools>=42", "wheel"]
 build-backend = "setuptools.build_meta"

--- a/setup.cfg
+++ b/setup.cfg
@@ -8,7 +8,7 @@ url = https://github.com/AngelFP/VisualPIC
 author = Angel Ferran Pousa
 author_email = angel.ferran.pousa@desy.de,
 license = GPLv3
-license_file = LICENSE
+license_files = LICENSE
 classifiers =
     Development Status :: 3 - Alpha
     Programming Language :: Python :: 3


### PR DESCRIPTION
Seen in Conda-Forge:
```
  !!

          ********************************************************************************
          The license_file parameter is deprecated, use license_files instead.

          This deprecation is overdue, please update your project and remove deprecated
          calls to avoid build errors in the future.

          See https://setuptools.pypa.io/en/latest/userguide/declarative_config.html for details.
          ********************************************************************************

  !!
```