### PR TITLE
Some changes to make VisualPIC work well with OSIRIS

### DIFF
--- a/visualpic/data_handling/data_container.py
+++ b/visualpic/data_handling/data_container.py
@@ -181,9 +181,9 @@ class DataContainer():
                 for field_name in required_fields:
                     base_fields.append(self.get_field(field_name))
 
-            self.derived_fields.append(DerivedField(
-                derived_field, sim_geometry, self.sim_params,
-                base_fields))
+                self.derived_fields.append(DerivedField(
+                    derived_field, sim_geometry, self.sim_params,
+                    base_fields))
 
     def _set_folder_scanner(self):
         """Return the folder scanner corresponding to the simulation code."""

--- a/visualpic/ui/basic_render_window.py
+++ b/visualpic/ui/basic_render_window.py
@@ -95,9 +95,9 @@ class BasicRenderWindow(QtWidgets.QMainWindow):
         self.hl.addWidget(self.next_button)
         self.timestep_slider = QtWidgets.QSlider(Qt.Horizontal)
         if len(self.available_timesteps) > 0:
-            self.timestep_slider.setRange(np.min(self.available_timesteps),
-                                          np.max(self.available_timesteps))
-            self.timestep_slider.setValue(self.vtk_vis.current_time_step)
+            self.timestep_slider.setRange(int(np.min(self.available_timesteps)),
+                                          int(np.max(self.available_timesteps)))
+            self.timestep_slider.setValue(int(self.vtk_vis.current_time_step))
         else:
             self.timestep_slider.setEnabled(False)
         self.hl.addWidget(self.timestep_slider)

--- a/visualpic/ui/basic_render_window.py
+++ b/visualpic/ui/basic_render_window.py
@@ -8,7 +8,6 @@ Copyright 2016-2020, Angel Ferran Pousa.
 License: GNU GPL-3.0.
 """
 
-
 from pkg_resources import resource_filename
 import platform
 import ctypes
@@ -24,8 +23,9 @@ from visualpic.ui.controls.qt.QVTKRenderWindowInteractor import (
 from visualpic.ui.setup_field_volume_window import SetupFieldVolumeWindow
 from visualpic.ui.setup_scatter_species_dialog import SetupScatterSpeciesDialog
 from visualpic.ui.render_settings_dialog import RenderSettingsDialog
-from visualpic.helper_functions import (
-    get_closest_timestep, get_previous_timestep, get_next_timestep)
+from visualpic.helper_functions import (get_closest_timestep,
+                                        get_previous_timestep,
+                                        get_next_timestep)
 
 # code for proper scaling in high-DPI screens. Move this somewhere else once \
 # final UI is implemented.
@@ -40,7 +40,6 @@ QtWidgets.QApplication.setStyle(QStyleFactory.create('Fusion'))
 
 
 class BasicRenderWindow(QtWidgets.QMainWindow):
-
     """Basic Qt window for interactive visualization of 3D renders."""
 
     def __init__(self, vtk_visualizer, parent=None, window_size=None):
@@ -95,8 +94,9 @@ class BasicRenderWindow(QtWidgets.QMainWindow):
         self.hl.addWidget(self.next_button)
         self.timestep_slider = QtWidgets.QSlider(Qt.Horizontal)
         if len(self.available_timesteps) > 0:
-            self.timestep_slider.setRange(int(np.min(self.available_timesteps)),
-                                          int(np.max(self.available_timesteps)))
+            self.timestep_slider.setRange(
+                int(np.min(self.available_timesteps)),
+                int(np.max(self.available_timesteps)))
             self.timestep_slider.setValue(int(self.vtk_vis.current_time_step))
         else:
             self.timestep_slider.setEnabled(False)

--- a/visualpic/ui/controls/mpl_figure_with_draggable_points.py
+++ b/visualpic/ui/controls/mpl_figure_with_draggable_points.py
@@ -32,8 +32,10 @@ class FigureWithDraggablePoints(Figure):
         self.patch_color = patch_color
         self.drag_points = {}
         self.histograms = {}
-        super().__init__(figsize, dpi, facecolor, edgecolor, linewidth,
-                         frameon, subplotpars, tight_layout)
+        super().__init__(figsize=figsize, dpi=dpi, facecolor=facecolor,
+                     edgecolor=edgecolor, linewidth=linewidth,
+                     frameon=frameon, subplotpars=subplotpars,
+                     tight_layout=tight_layout)
         self.create_axes(nrows, ncols, xlabels, ylabels, share_x_axis,
                          share_y_axis, hist, hist_edges)
 

--- a/visualpic/ui/controls/mpl_figure_with_draggable_points.py
+++ b/visualpic/ui/controls/mpl_figure_with_draggable_points.py
@@ -32,10 +32,11 @@ class FigureWithDraggablePoints(Figure):
         self.patch_color = patch_color
         self.drag_points = {}
         self.histograms = {}
-        super().__init__(figsize=figsize, dpi=dpi, facecolor=facecolor,
-                     edgecolor=edgecolor, linewidth=linewidth,
-                     frameon=frameon, subplotpars=subplotpars,
-                     tight_layout=tight_layout)
+        super().__init__(
+            figsize=figsize, dpi=dpi, facecolor=facecolor,
+            edgecolor=edgecolor, linewidth=linewidth,
+            frameon=frameon, subplotpars=subplotpars,
+            tight_layout=tight_layout)
         self.create_axes(nrows, ncols, xlabels, ylabels, share_x_axis,
                          share_y_axis, hist, hist_edges)
 


### PR DESCRIPTION
VisualPIC is such a wonderful tool to visualize 3D PIC data!
Recently, I encountered some issues while using it to process my OSIRIS-3D data. I found that making the following changes can resolve them. Furthermore, I have tested the compatibility of the modified code with openPMD format data, and I believe these changes should be safe.

1. The `add_derived_field()` function in `visualpic/data_handling/data_container.py` performs normally when using openPMD data, but will report the following errors that ` cannot access local variable 'base_fields' where it is not associated with a value` when loading OSIRIS data. Notice that before the `Reuse add_derived_field` commit, the `add_derived_field()` was implemented actually within the `_generate_derived_fields(self)` function, and the line `derived_field_list.append(...)` would be executed only when the condition `if set(required_fields).issubset(folder_field_names):` was met. So I do the same in the `add_derived_field()` function.
2. The `setup_interface():` function in the `visualpic/ui/basic_render_window.py` will report `setRange(self, min: int, max: int): argument 1 has unexpected type 'numpy.float64'` only when using OSIRIS-3D data. And I convert the relevant variables to integer type to solve the issue.
3. I changed the `__init__` function in `visualpic/ui/controls/mpl_figure_with_draggable_points.py` to solve the issue that whenever I try to edit visual properties, it reports `Figure.__init__() takes from 1 to 3 positional arguments but 9 were given`. This issue also happens when using openPMD data.

I hope these small changes can help.
Best regards!