### PR TITLE
Improvements to laser analysis module and data with time axis

### DIFF
--- a/visualpic/data_handling/field_data.py
+++ b/visualpic/data_handling/field_data.py
@@ -40,6 +40,12 @@ class FieldData(np.lib.mixins.NDArrayOperatorsMixin):
         self._metadata = metadata
         self._geometry = geometry
         self._units = units
+        for axis in self.axis_labels:
+            if not hasattr(self, axis):
+                setattr(self, axis, getattr(metadata, axis))
+                setattr(self, f"d{axis}", getattr(metadata, f"d{axis}"))
+                setattr(self, f"{axis}_min", getattr(metadata, f"{axis}min"))
+                setattr(self, f"{axis}_max", getattr(metadata, f"{axis}max"))
         self._legacy_metadata = self._create_legacy_metadata()
         self._legacy_api = (self.array, self._legacy_metadata)
         # Enable some array-like functionality (such as passing to matplotlib).
@@ -106,7 +112,7 @@ class FieldData(np.lib.mixins.NDArrayOperatorsMixin):
     @array.setter
     def array(self, new_array):
         assert self._array.shape == new_array.shape
-        self._array = new_array
+        self._array[:] = new_array
 
     @property
     def geometry(self) -> str:

--- a/visualpic/data_handling/fields.py
+++ b/visualpic/data_handling/fields.py
@@ -42,6 +42,10 @@ class Field():
         self._ts = timeseries
 
     @property
+    def _metadata(self) -> Dict:
+        return self._ts.fields_metadata[self.name]
+
+    @property
     def name(self) -> str:
         return self._name
 
@@ -55,7 +59,11 @@ class Field():
 
     @property
     def geometry(self) -> str:
-        return self._ts.fields_metadata[self._name]['geometry']
+        return self._metadata['geometry']
+    
+    @property
+    def axis_labels(self) -> List:
+        return self._metadata['axis_labels']
 
     @property
     def field_name(self) -> str:
@@ -218,6 +226,10 @@ class DerivedField(Field):
     @property
     def geometry(self):
         return self._sim_geometry
+    
+    @property
+    def axis_labels(self):
+        self._base_fields[0].axis_labels
 
     def get_data(
         self,


### PR DESCRIPTION
- Fix bug when using `lru_cache` in `get_data`: attributes cannot be lists.
- Revert back envelope array to original shape after using lasy.
- Add `axis_labels` property to `Field`.
- Improve support for data where time is one of the array axes.